### PR TITLE
initial spike of commands

### DIFF
--- a/heroku/deploy.yml
+++ b/heroku/deploy.yml
@@ -1,0 +1,21 @@
+type: command
+name: Deploy to heroku
+steps:
+- add_ssh_keys: {}
+- deploy:
+    name: Maybe deploy to heroku
+    command: |
+      DEPLOY_BRANCH=${CIRCLE_CMD_DEPLOY_BRANCH:-master}
+      DEPLOY_APP=${CIRCLE_CMD_APP_NAME:-CIRCLE_PROJECT_REPONAME}
+
+      if [ "${CIRCLE_BRANCH}" == "${CMD_DEPLOY_BRANCH}" ]
+      then
+        # Install Heroku fingerprint
+        mkdir -p ~/.ssh
+        echo 'heroku.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAu8erSx6jh+8ztsfHwkNeFr/SZaSOcvoa8AyMpaerGIPZDB2TKNgNkMSYTLYGDK2ivsqXopo2W7dpQRBIVF80q9mNXy5tbt1WE04gbOBB26Wn2hF4bk3Tu+BNMFbvMjPbkVlC2hcFuQJdH4T2i/dtauyTpJbD/6ExHR9XYVhdhdMs0JsjP/Q5FNoWh2ff9YbZVpDQSTPvusUp4liLjPfa/i0t+2LpNCeWy8Y+V9gUlDWiyYwrfMVI0UwNCZZKHs1Unpc11/4HLitQRtvuk0Ot5qwwBxbmtvCDKZvj1aFBid71/mYdGRPYZMIxq1zgP1acePC1zfTG/lvuQ7d0Pe0kaw==' >> ~/.ssh/known_hosts
+
+        git config --global push.default simple
+        git push -f git@heroku.com:${DEPLOY_APP}.git
+      else
+        echo Not deploying. Found branch ${CIRCLE_BRANCH} but only deploy on ${DEPLOY_BRANCH} builds
+      fi

--- a/node/commands/dependencies.yml
+++ b/node/commands/dependencies.yml
@@ -5,13 +5,12 @@ descriptions: |
 steps:
 - restore_cache:
     keys:
-      - v2-node-dependencies-{{ checksum "package.json" }}
-      - v2-node-dependencies-
+      - v1-node-dependencies-{{ checksum "package.json" }}
+      - v1-node-dependencies-
 - run:
-    name: yarn install
+    name: Install node dependencies
     command: yarn install || yarn install || yarn install
 - save_cache:
-    key: v2-node-dependencies-{{ checksum "package.json" }}
+    key: v1-node-dependencies-{{ checksum "package.json" }}
     paths:
       - node_modules
-      - ~/.cache/yarn

--- a/node/commands/test.yml
+++ b/node/commands/test.yml
@@ -2,5 +2,5 @@ type: command
 name: Run tests
 steps:
 - run:
-    name: test
+    name: Run node tests
     command: yarn test

--- a/ruby/commands/dependencies.yml
+++ b/ruby/commands/dependencies.yml
@@ -1,0 +1,22 @@
+type: command
+name: Install Ruby dependencies
+descriptions: |
+  install ruby dependencies and cache them
+steps:
+- restore_cache:
+    name: Restore ruby dependencies
+    keys:
+      - v1-ruby-dependencies-{{ checksum "Gemfile" }}
+      - v1-ruby-dependencies-
+- run:
+    name: Install ruby dependencies
+    command: bundle install --path vendor/bundle --job=4 --retry=3
+    environment:
+      RAILS_ENV: test
+      RACK_ENV: test
+- save_cache:
+    name: Save ruby dependencies
+    key: v1-ruby-dependencies-{{ checksum "Gemfile" }}
+    paths:
+      - vendor/bundle
+

--- a/ruby/commands/rspec.yml
+++ b/ruby/commands/rspec.yml
@@ -1,0 +1,32 @@
+type: command
+name: Run rspec tests
+description: |
+  run rspec tests
+steps:
+- run:
+    name: Run rspec tests
+    command: |
+      mkdir -p /tmp/test-results/rspec
+
+      if [ "$CIRCLE_NODE_TOTAL" == "1" ]
+      then
+        bundle exec rspec --format documentation --format RspecJunitFormatter \
+          --out /tmp/test-results/rspec/rspec.xml
+      else
+        TESTFILES=$(picard tests glob "spec/**/*_spec.rb" | picard tests split --split-by=timings)
+        if [ -z "$TESTFILES" ]
+        then
+          echo 'No tests are scheduled to be executed on this node'
+          exit 0
+        fi
+
+        echo Node is running "$TESTFILES" >/dev/stderr
+        bundle exec rspec --format documentation --format RspecJunitFormatter \
+          --out /tmp/test-results/rspec/rspec.xml "$TESTFILES"
+      fi
+    environment:
+      RAILS_ENV: test
+      RACK_ENV: test
+
+- store_test_results:
+    path: /tmp/test-results/rspec


### PR DESCRIPTION
A sample try for internal use for the commands.  The idea is that commands will be able to invoke them from circle.yml like the following:

```yaml
steps:
- checkout
- ruby/dependencies
- ruby/rspec
```

There are few things to be learned before we expose these to customers - namely the following:

1. figure out how what to expose as parameterized options and what should be considered baked in.  For example, rspec option may require use customizations for the rspec flags, the glob file to be used, exclusions, etc.  What's the right balance?

2. How should we version these commands effectively and changelog them?  We need to solve this before we expose it to customers.

@zzak mind if you take a look into the ruby commands?  I noticed that 1.0 handles parsing the content of `.rspec` file and passing them to `rspec` yet [the rspec docs](https://www.relishapp.com/rspec/rspec-core/docs/configuration/read-command-line-configuration-options-from-files) claims that the file should be read automatically.