### PR TITLE
Generate Android SDK 25 image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/*/images/
+/*/resources/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUNDLES = \
   postgres mysql mongo elixir \
   clojure openjdk
 
-images: $(foreach b, $(BUNDLES), $(b)/generate_images)
+images: $(foreach b, $(BUNDLES), $(b)/generate_images) generate_android
 
 publish_images: images
 	find . -name Dockerfile -exec ./shared/images/build.sh {} \;
@@ -16,3 +16,6 @@ publish_images: images
 
 %/publish_image:
 	echo $(@D)
+
+generate_android:
+	cd android; bash generate-images

--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -1,0 +1,40 @@
+FROM openjdk:8-jdk
+
+# Skip the first line of the Dockerfile template (FROM ${BASE})
+syscmd(`tail -n +2 ../shared/images/Dockerfile-basic.template')
+
+ARG sdk_version=sdk-tools-linux-3859397.zip
+ARG android_home=/opt/android/sdk
+
+# SHA-256 444e22ce8ca0f67353bda4b85175ed3731cae3ffa695ca18119cbacef1c1bea0
+
+RUN sudo apt-get update && \
+    sudo apt-get install --yes xvfb gcc-multilib lib32z1 lib32stdc++6
+
+# Download and install Android SDK
+RUN sudo mkdir -p ${android_home} && \
+    sudo chown -R circleci:circleci ${android_home} && \
+    curl --output /tmp/${sdk_version} https://dl.google.com/android/repository/${sdk_version} && \
+    unzip -q /tmp/${sdk_version} -d ${android_home} && \
+    rm /tmp/${sdk_version}
+
+# Set environmental variables
+ENV ANDROID_HOME ${android_home}
+ENV ADB_INSTALL_TIMEOUT 120
+ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}
+
+RUN mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
+
+RUN sdkmanager --update && yes | sdkmanager --licenses
+
+# Update SDK manager and install system image, platform and build tools
+RUN echo y | sdkmanager "tools"
+RUN echo y | sdkmanager "platform-tools"
+RUN echo y | sdkmanager "extras;android;m2repository"
+RUN echo y | sdkmanager "extras;google;m2repository"
+RUN echo y | sdkmanager "extras;google;google_play_services"
+RUN echo y | sdkmanager "emulator"
+RUN echo y | sdkmanager "build-tools;25.0.3"
+RUN echo y | sdkmanager "system-images;android-25;google_apis;armeabi-v7a"
+RUN echo y | sdkmanager "platforms;android-25"
+

--- a/android/generate-images
+++ b/android/generate-images
@@ -1,0 +1,5 @@
+echo Generating Android API 25 Dockerfile
+
+TAG=api-25-alpha
+mkdir -p images/${TAG}
+m4 Dockerfile.m4 > images/${TAG}/Dockerfile


### PR DESCRIPTION
This change adds a new target to the makefile to generate

     android/images/api-25-alpha/Dockerfile

which is a Dockerfile that generates a CircleCI blessed image for
running Android builds. I have alpha in the tag name so that we can
iterate on the container image.

I have punted on generating other Android API levels for now, until we
can see how this is working with customers.