### PR TITLE
[Build] Remove images after pushing

### DIFF
--- a/shared/images/build.sh
+++ b/shared/images/build.sh
@@ -34,4 +34,6 @@ fi
 
 docker push $IMAGE_NAME
 
+docker image rm $IMAGE_NAME
+
 popd


### PR DESCRIPTION
Remove images after running `docker push` to prevent images with many
tags from running out of disk space.