### PR TITLE
Don't use `--force-yes` for `apt-get` => insecure actions

### DIFF
--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -2,7 +2,6 @@ FROM {{BASE_IMAGE}}
 
 # make Apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'APT::Get::force-Yes "true";' >> /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] Tried to run the CircleCI workflow on this fork's master branch. Not working. Result:

      We weren't able to start this workflow.
      Job "publish_android" has filters configured in the job definition. These filters are incompatible with workflows. [...]
   See the [CircleCI Discuss topic](https://discuss.circleci.com/t/cant-run-workflow-at-circleci-images-fork/14788).
     
- [ ] ~I've updated the documentation if necessary.~

### Motivation and Context

This setting allows insecure operations, including [installing unauthenticated packages](https://github.com/Debian/apt/blob/master/apt-private/private-download.cc#L81). It is also deprecated.

I tested the remove of this setting in our own build image.

### Description
Removed `APT::Get::force-Yes`.
