### PR TITLE
Node added an Architecture field; we need one more line

### DIFF
--- a/ruby/generate-images
+++ b/ruby/generate-images
@@ -19,7 +19,7 @@ FROM {{BASE_IMAGE}}
 USER root
 EOF
 
-  NODE_MANIFEST_INFO=$(curl --silent --location --fail --retry 3 https://raw.githubusercontent.com/docker-library/official-images/master/library/node | grep -A2 $DESIRED_NODE_TAG)
+  NODE_MANIFEST_INFO=$(curl --silent --location --fail --retry 3 https://raw.githubusercontent.com/docker-library/official-images/master/library/node | grep -A3 $DESIRED_NODE_TAG)
   NODE_GIT_COMMIT=$(printf "%s\n" "${NODE_MANIFEST_INFO}" | grep GitCommit | awk '{print $2;}')
   NODE_DIRECTORY=$(printf "%s\n" "${NODE_MANIFEST_INFO}" | grep Directory | awk '{print $2;}')
 


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to an issue where node was no longer being installed on the Ruby images.

### Description

Node pushed an update to their metadata that adds an additional Architecture line (or reorders the output). My change greps one additional line for a given tag, giving us sufficient data to pull in their Dockerfile.
