### PR TITLE
Cache tools And Other stuff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,14 @@ jobs:
           path: /tmp/dockerfiles
           destination: Dockerfiles
 
+  refresh_tools_cache:
+    docker:
+    - image: circleci/python:latest
+    steps:
+    - checkout
+    - run: sudo pip install awscli
+    - run: cd ./shared/images; ./refresh-tools-cache
+
   publish_image: &publish_image
     machine: true
     working_directory: ~/circleci-bundles
@@ -109,7 +117,7 @@ jobs:
 
 workflow_filters: &workflow_filters
   requires:
-    - generate_dockerfiles
+    - refresh_tools_cache
   filters:
     branches:
       only:
@@ -122,6 +130,15 @@ workflows:
   build_test_deploy:
     jobs:
       - generate_dockerfiles
+      - refresh_tools_cache:
+          requires:
+          - generate_dockerfiles
+          filters:
+            branches:
+              only:
+                - master
+                - production
+                - parallel
       - publish_android:  *workflow_filters
       - publish_node:     *workflow_filters
       - publish_python:   *workflow_filters

--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -4,46 +4,63 @@ NAME=Java
 BASE_REPO=openjdk
 VARIANTS=(browsers)
 
-TAG_FILTER="grep -v -e ^7 -e ^6"
+TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
 
 function generate_customizations() {
 
   MAVEN_VERSION=$(./java_helper maven)
   ANT_VERSION=$(./java_helper ant)
   GRADLE_VERSION=$(./java_helper gradle)
-  SBT_VERSION=$(./java_helper sbt)
+  SBT_URL=$(./java_helper sbt)
 
-  printf "\n# Install Maven Version: $MAVEN_VERSION\n"
-  echo "RUN wget http://mirrors.advancedhosters.com/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz"
-  echo "RUN tar xf apache-maven-$MAVEN_VERSION-bin.tar.gz -C /opt/"
-  echo "RUN rm apache-maven-$MAVEN_VERSION-bin.tar.gz"
+  cat <<EOF
 
-  printf "\n# Install Ant Version: $ANT_VERSION\n"
-  echo "RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz"
-  echo "RUN tar xf apache-ant-$ANT_VERSION-bin.tar.gz -C /opt/"
-  echo "RUN rm apache-ant-$ANT_VERSION-bin.tar.gz"
+# Install Maven Version: $MAVEN_VERSION
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz \
+    https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && tar xf /tmp/apache-maven.tar.gz -C /opt/ \
+  && rm /tmp/apache-maven.tar.gz \
+  && ln -s /opt/apache-maven-* /opt/apache-maven \
+  && /opt/apache-maven/bin/mvn -version
 
-  printf "\n# Install Gradle Version: $GRADLE_VERSION\n"
-  echo "RUN mkdir /opt/gradle"
-  echo "RUN wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
-  echo "RUN unzip -d /opt/gradle gradle-$GRADLE_VERSION-bin.zip"
-  echo "RUN rm gradle-$GRADLE_VERSION-bin.zip"
+# Install Ant Version: $ANT_VERSION
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz \
+    https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+  && tar xf /tmp/apache-ant.tar.gz -C /opt/ \
+  && ln -s /opt/apache-ant-* /opt/apache-ant \
+  && rm -rf /tmp/apache-ant.tar.gz \
+  && /opt/apache-ant/bin/ant -version
 
-  printf "\n# Install sbt Version: $SBT_VERSION\n"
-  echo "RUN mkdir /opt/sbt"
-  echo "RUN wget https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.zip"
-  echo "RUN unzip -d /opt sbt-$SBT_VERSION.zip"
-  echo "RUN rm sbt-$SBT_VERSION.zip"
+ENV ANT_HOME=/opt/apache-ant
 
-  printf "\n# Update PATH for Java tools\n"
-  echo "ENV ANT_HOME=/opt/apache-ant-$ANT_VERSION"
-  echo "ENV PATH='/opt/sbt/bin:/opt/apache-maven-$MAVEN_VERSION/bin:/opt/apache-ant-$ANT_VERSION/bin:/opt/gradle/gradle-$GRADLE_VERSION/bin:$PATH'"
+# Install Gradle Version: $GRADLE_VERSION
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip \
+    https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  && unzip -d /opt /tmp/gradle.zip \
+  && rm /tmp/gradle.zip \
+  && ln -s /opt/gradle-* /opt/gradle \
+  && /opt/gradle/bin/gradle -version
 
-  printf "\n# smoke test"
-  echo "RUN mvn -version"
-  echo "RUN ant -version"
-  echo "RUN gradle -version"
-  echo "RUN sbt sbtVersion"
+# Install sbt from $SBT_URL
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz ${SBT_URL} \
+  && tar -xzf /tmp/sbt.tgz -C /opt/ \
+  && rm /tmp/sbt.tgz \
+  && /opt/sbt/bin/sbt sbtVersion
+
+EOF
+
+  # Modify path but don't inject builder path in there!
+  cat <<'EOF'
+# Update PATH for Java tools
+ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin:$PATH"
+
+# smoke test with path
+RUN mvn -version
+RUN ant -version
+RUN gradle -version
+RUN sbt sbtVersion
+
+EOF
 }
 
 IMAGE_CUSTOMIZATIONS=$(generate_customizations)

--- a/openjdk/java_helper
+++ b/openjdk/java_helper
@@ -15,7 +15,7 @@ GRADLE_VERSION_PATTERN = r'(<span>v\d+\.\d+(\.\d+)?)'
 ANT_URL = 'http://archive.apache.org/dist/ant/binaries/'
 ANT_VERSION_PATTERN = r'\d+\.\d+\.\d+'
 SBT_URL = 'http://www.scala-sbt.org/download.html'
-SBT_VERSION_PATTERN = r'sbt-\d+\.\d+\.\d+'
+SBT_URL_PATTERN = r'https://[^"]*tgz'
 
 def get_latest_version(url, pattern):
     """Return latest version of given tool 
@@ -38,6 +38,14 @@ def get_latest_version(url, pattern):
             'Unable to find any versions from {0}, this is not expected'.format(url))
     return versions[((len(versions) - 1))]
 
+def get_sbt_url(url, pattern):
+    raw_html = urllib2.urlopen(url).read()
+    raw_urls = re.findall(pattern, raw_html)
+    if (len(raw_urls) < 1):
+        raise Exception(
+            'Unable to find any urls from {0}, this is not expected'.format(url))
+    return raw_urls[((len(raw_urls) - 1))]
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Get Latest Version of Java Tools.')
     parser.add_argument('get', type=str, choices=['ant', 'gradle', 'maven', 'sbt'], 
@@ -50,4 +58,4 @@ if __name__ == '__main__':
     if args.get == 'maven':
         print(get_latest_version(MAVEN_URL, MAVEN_VERSION_PATTERN))
     if args.get == 'sbt':
-        print(get_latest_version(SBT_URL, SBT_VERSION_PATTERN))
+        print(get_sbt_url(SBT_URL, SBT_URL_PATTERN))

--- a/php/generate-images
+++ b/php/generate-images
@@ -13,7 +13,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
-RUN pecl install xdebug && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so"' > /etc/php/xdebug.ini
+RUN mkdir -p /etc/php && pecl install xdebug && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so"' > /etc/php/xdebug.ini
 
 EOF
 )

--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -21,7 +21,7 @@ RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
 # install jq
-RUN JQ_URL=$(curl --location --fail --retry 3 https://api.github.com/repos/stedolan/jq/releases/latest  | grep browser_download_url | grep '/jq-linux64"' | grep -o -e 'https.*jq-linux64') \
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
   && chmod +x /usr/bin/jq \
   && jq --version
@@ -51,13 +51,13 @@ RUN set -ex \
   && (docker version || true)
 
 # docker compose
-RUN COMPOSE_URL=$(curl --location --fail --retry 3 https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[] | select(.name == "docker-compose-Linux-x86_64") | .browser_download_url') \
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # install dockerize
-RUN DOCKERIZE_URL=$(curl --location --fail --retry 3 https://api.github.com/repos/jwilder/dockerize/releases/latest | jq -r '.assets[] | select(.name | startswith("dockerize-linux-amd64")) | .browser_download_url') \
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
   && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
   && rm -rf /tmp/dockerize-linux-amd64.tar.gz \

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -5,11 +5,11 @@ FROM {{BASE_IMAGE}}
 #
 ## install phantomjs
 #
-RUN export PHANTOMJS_VERSION=$(curl --location --fail --retry 3  https://api.github.com/repos/ariya/phantomjs/tags | jq -r '.[0].name') \
+RUN PHANTOMJS_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/phantomjs-latest.tar.bz2" \
   && sudo apt-get update; sudo apt-get install libfontconfig \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/phantomjs.tar.bz2 ${PHANTOMJS_URL} \
   && tar -x -C /tmp -f /tmp/phantomjs.tar.bz2 \
-  && sudo mv /tmp/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs /usr/local/bin \
+  && sudo mv /tmp/phantomjs-*-linux-x86_64/bin/phantomjs /usr/local/bin \
   && rm -rf /tmp/phantomjs.tar.bz2 /tmp/phantomjs-* \
   && phantomjs --version
 
@@ -19,7 +19,8 @@ RUN export PHANTOMJS_VERSION=$(curl --location --fail --retry 3  https://api.git
 # If you are upgrading to any version newer than 47.0.1, you must check the compatibility with
 # selenium. See https://github.com/SeleniumHQ/selenium/issues/2559#issuecomment-237079591
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.deb https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build_47.0.1-0ubuntu1_amd64.deb \
+RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build_47.0.1-0ubuntu1_amd64.deb" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.deb $FIREFOX_URL \
   && echo 'ef016febe5ec4eaf7d455a34579834bcde7703cb0818c80044f4d148df8473bb  /tmp/firefox.deb' | sha256sum -c \
   && sudo dpkg -i /tmp/firefox.deb || sudo apt-get -f install  \
   && sudo apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 \

--- a/shared/images/refresh-tools-cache
+++ b/shared/images/refresh-tools-cache
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Helper file for creating a binary cache in S3 to avoid
+# hitting GitHub/VCS API rate limiting problems.
+
+set -exu
+
+function refresh_cache() {
+	NAME="$1"
+	URL="$2"
+
+	echo ">>> REFRESHING $NAME"
+	echo ''
+
+	TEMP_PATH="$(mktemp)"
+
+	curl --location --fail --retry 3 \
+		-o ${TEMP_PATH} \
+		"$URL"
+
+	echo "SHA256 of downloaded file was:"
+	sha256sum "${TEMP_PATH}" || true
+
+	aws s3 cp --acl public-read \
+		"${TEMP_PATH}" \
+		"s3://circle-downloads/circleci-images/cache/linux-amd64/${NAME}"
+
+	rm "${TEMP_PATH}"
+}
+
+
+# jq
+refresh_cache jq-latest \
+	$(curl --location --fail --retry 3 https://api.github.com/repos/stedolan/jq/releases/latest  | grep browser_download_url | grep '/jq-linux64"' | grep -o -e 'https.*jq-linux64')
+
+refresh_cache docker-compose-latest \
+	$(curl --location --fail --retry 3 https://api.github.com/repos/docker/compose/releases/latest | jq -r '.assets[] | select(.name == "docker-compose-Linux-x86_64") | .browser_download_url')
+
+refresh_cache dockerize-latest.tar.gz \
+	$(curl --location --fail --retry 3 https://api.github.com/repos/jwilder/dockerize/releases/latest | jq -r '.assets[] | select(.name | startswith("dockerize-linux-amd64")) | .browser_download_url')
+
+PHANTOMJS_VERSION=$(curl --location --fail --retry 3  https://api.github.com/repos/ariya/phantomjs/tags | jq -r '.[0].name')
+refresh_cache phantomjs-latest.tar.bz2 \
+	"https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

A bit of a giant PR in order to get circleci-images green.

Lots of failures are due to hitting the GitHub/BitBucket API rate limits.  Instead of relying on that to download latest, let's cache them in S3 and download from there.  Notice that I'm using `latest` here instead of a concrete version.  I have considered using concrete versions so it's easy for us to switch back.  However, given that we don't pin versions now and always use latest, and users desiring to pin can always lookup the actual github url 

Also, fix SBT again :(.  SBT 0.13.6 was released and updated in GitHub without the zipfiles in https://github.com/sbt/sbt/releases - as of yet.  Therefore let's just download it from the SBT website link.

Lastly, noticed that OpenJDK dockerfile inserts the building container `PATH`!  Fixing that with better escaping behavior.

