### PR TITLE
PHP: don't support RC/beta releases

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -4,6 +4,8 @@ NAME=PHP
 BASE_REPO=php
 VARIANTS=(browsers node node-browsers)
 
+TAG_FILTER="grep -v -e rc -e beta"
+
 IMAGE_CUSTOMIZATIONS=$(cat <<'EOF'
 
 # Install composer


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

PHP Builds are failing for the rc/beta tags.

Xdebug tools don't support RC/beta releases yet:

```
checking whether to enable Xdebug support... yes, shared
checking Check for supported PHP versions... configure: error: not supported. Need a PHP version >= 5.5.0 and < 7.2.0 (found 7.2.0beta2)
ERROR: `/tmp/pear/temp/xdebug/configure --with-php-config=/usr/local/bin/php-config' failed
The command '/bin/sh -c mkdir -p /etc/php && pecl install xdebug && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so"' > /etc/php/xdebug.ini' returned a non-zero code: 1
make[1]: *** [php/images/rc/publish_image] Error 1
```
