### PR TITLE
Build image once and tag aliases

### DIFF
--- a/shared/images/build.sh
+++ b/shared/images/build.sh
@@ -5,29 +5,46 @@ set -eu
 NEW_ORG=${NEW_ORG:-circleci}
 
 DOCKERFILE_PATH=$1
+pushd $(dirname $DOCKERFILE_PATH)
 
 echo Building docker image from $DOCKERFILE_PATH
 
-function image_name() {
-  repo_tag=$( echo ${DOCKERFILE_PATH} | sed 's|.*/\([^/]*\)/images/\(.*\)/Dockerfile|\1:\2|g' | sed 's|/|-|g')
+function repo_name() {
+  repo_tag=$( echo ${DOCKERFILE_PATH} | sed 's|.*/\([^/]*\)/images/.*/Dockerfile|\1|g')
   echo "${NEW_ORG}/${repo_tag}"
 }
 
-IMAGE_NAME=$(image_name)
+REPO_NAME=$(repo_name)
+IMAGE_NAME=${REPO_NAME}:$(cat TAG)
+
+
+echo "OFFICIAL IMAGE REF: $IMAGE_NAME"
 
 function is_variant() {
-      echo $IMAGE_NAME | grep -q -
+    echo ${DOCKERFILE_PATH} | grep -q -e 'images/.*/Dockerfile'
 }
 
-pushd $(dirname $DOCKERFILE_PATH)
+function update_aliases() {
+    for alias in $(cat ALIASES | sed 's/,/ /g')
+    do
+        echo handling alias ${alias}
+        ALIAS_NAME=${REPO_NAME}:${alias}
+        docker tag ${IMAGE_NAME} ${ALIAS_NAME}
+        docker push ${ALIAS_NAME}
+        docker image rm ${ALIAS_NAME}
+    done
+}
 
 # pull to get cache and avoid recreating images unnecessarily
 docker pull $IMAGE_NAME || true
 
 if is_variant
 then
+    echo "image is a variant image"
     docker build -t $IMAGE_NAME .
     docker push $IMAGE_NAME
+
+    update_aliases
 
     # variants don't get reused, clean them up
     docker image rm $IMAGE_NAME
@@ -36,6 +53,8 @@ else
     # also keep new base images around for variants
     docker build --pull -t $IMAGE_NAME .
     docker push $IMAGE_NAME
+
+    update_aliases
 fi
 
 popd


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

A single official image may have multiple tags.  Currently, `7.1.8-fpm` is aliased to `7.1-fpm, 7-fpm, fpm` - and this results into independent docker image builds for each of these tags.  We rely on cache to speed up builds but our build scripts is aggressive in deleting caches for variants and the like, causing real independent builds.

This PR speeds up builds and ensure that we build a single image and tag it multiple times eliminate the chance of the tags being slightly out of sync.

### Description

Frequently official images use many aliases (e.g. latest).  Build image
once and tag aliases instead of building multiple times and assuming
Docker cache will sort it out.

The implementation uses a TAG and ALIASES file on the generated paths.
TAG contains the canonical tag.  ALIASES contains comma separated values
with the aliases this image should have.

Also, noticed that we treat some images as invariant mistakenly because
the official image has a dash, e.g. `7.1.2-fpm`.  Fixed it by checking
whether Dockerfile isn't a direct child of images folder instead.
