### PR TITLE
use docker-php-ext-enable command to enable xdebug

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -15,7 +15,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
-RUN mkdir -p /etc/php && ( pecl install xdebug || pecl install xdebug ) && echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so"' > /etc/php/xdebug.ini
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 EOF
 )


### PR DESCRIPTION
### Checklist
- [x ] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x ] I've updated the documentation if necessary. (not necessary in this update)

### Motivation and Context

This PR is not related to an existing issue, its related to an issue I encountered while trying to setup phpunit with coverage text.

The change is required, because xdebug is not correctly enabled, so the coverage drivers where not found and it was not showing on `phpinfo()` output or `php -i`.

Initially built image 7.1.9-cli and ssh'd into it, tried installing and enabling xdebug, to find out that it was indeed installed, just not enabled. Enabled it using the `docker-php-ext-enable` command provided by the php docker image (our base) and got expected result from `php -i` and running `phpunit` on my project.

### Description
It modifies the line in which xdebug is installed and enabled to use `docker-php-ext-enable xdebug`

**Disclaimer**: Did not build and run all php images to test if it working as expected.