### PR TITLE
Add support for API 27

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -83,6 +83,7 @@ RUN sdkmanager \
   "build-tools;25.0.2" \
   "build-tools;25.0.3" \
   "build-tools;26.0.1" \
-  "build-tools;26.0.2"
+  "build-tools;26.0.2" \
+  "build-tools;27.0.0"
 
 RUN sdkmanager "platforms;android-API_LEVEL"

--- a/android/generate-images
+++ b/android/generate-images
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-for API in 23 24 25 26; do
+for API in 23 24 25 26 27; do
   echo Generating Android ${API} Dockerfile
   TAG=api-${API}-alpha
   mkdir -p images/${TAG}


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `make` from the root directory to see all Dockerfiles are created successfully. 
_I've run `generate-images` in the `android` directory and `docker build .` from `android/images/api-27-alpha` successfully. Can do this whole step if you want.
- [x] I've updated the documentation if necessary.

### Motivation and Context

Android API 27 is out, as well as Build Tools 27.0.0. We'd like to use these in our project.

### Description
Based on https://github.com/circleci/circleci-images/pull/88, I've added the new Build Tools, and I've added 27 to the list of API version that images are generated for.
