### PR TITLE
Switch Node Docker tag from latest to '8.9'for Node variants.

### DIFF
--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -37,6 +37,6 @@ function generate_node_browser_variant() {
 }
 
 mkdir -p resources
-generate_node_variant "latest" > resources/Dockerfile-node.template
+generate_node_variant "8.9" > resources/Dockerfile-node.template
 generate_node_browser_variant > resources/Dockerfile-node-browsers.template
 

--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -37,6 +37,6 @@ function generate_node_browser_variant() {
 }
 
 mkdir -p resources
-generate_node_variant "8" > resources/Dockerfile-node.template
+generate_node_variant "carbon$" > resources/Dockerfile-node.template
 generate_node_browser_variant > resources/Dockerfile-node-browsers.template
 

--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -37,6 +37,6 @@ function generate_node_browser_variant() {
 }
 
 mkdir -p resources
-generate_node_variant "8.9" > resources/Dockerfile-node.template
+generate_node_variant "8" > resources/Dockerfile-node.template
 generate_node_browser_variant > resources/Dockerfile-node-browsers.template
 


### PR DESCRIPTION
Fixes #95 

Pinning the NodeJS version used in `-node` variants to the current NodeJS LTS release. Pinning the major and minor version. Point releases will be updated regularly.

The current LTS release is NodeJS v8.9.0. Pinning to `node/8.9`.