### PR TITLE
Downgrade bundler to 1.15.4 as 1.16 has a breaking change

### DIFF
--- a/ruby/generate-images
+++ b/ruby/generate-images
@@ -4,8 +4,7 @@ NAME=Ruby
 BASE_REPO=ruby
 VARIANTS=(browsers node node-browsers)
 IMAGE_CUSTOMIZATIONS='
-RUN if [[ ${BUNDLER_VERSION} == "1.16.0" ]]; then gem uninstall -a -x --force bundler && \
-  gem install bundler -v "1.15.4"; fi
+RUN if [ "x$BUNDLER_VERSION" = "1.16.0" ] ; then echo Using current bundler ; else sudo gem uninstall -a -x --force bundler && gem install bundler -v "1.15.4" ; fi
 '
 
 source ../shared/images/generate-node.sh

--- a/ruby/generate-images
+++ b/ruby/generate-images
@@ -3,6 +3,10 @@
 NAME=Ruby
 BASE_REPO=ruby
 VARIANTS=(browsers node node-browsers)
+IMAGE_CUSTOMIZATIONS='
+RUN if [[ ${BUNDLER_VERSION} == "1.16.0" ]]; then gem uninstall -a -x --force bundler && \
+  gem install bundler -v "1.15.4"; fi
+'
 
 source ../shared/images/generate-node.sh
 source ../shared/images/generate.sh


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.

### Motivation and Context

This PR relates to #98.

On Ruby versions < 2.5, bundler 1.16.0 is pre-installed on the upstream images, which has a breaking change affecting some % of users.

We should pin bundler to a stable version to avoid breaking peoples builds, which will our users time and our support team tickets.

### Description

Using `IMAGE_CUSTOMIZATIONS` allows us to hook into the Dockerfile generator to append some commands. In this case we want to uninstall bundler 1.16 and install the stable version 1.15.4.

I've downloaded the Dockerfiles from a successful build and tested the images. Everything works except the 2.5 preview image because the way Ruby packages bundler as a default gem, in the standard library, it can't be removed so easily.