### PR TITLE
Revert bundler pinning

### DIFF
--- a/ruby/generate-images
+++ b/ruby/generate-images
@@ -3,9 +3,6 @@
 NAME=Ruby
 BASE_REPO=ruby
 VARIANTS=(browsers node node-browsers)
-IMAGE_CUSTOMIZATIONS='
-RUN if [ "x$BUNDLER_VERSION" = "1.16.0" ] ; then echo Using current bundler ; else sudo gem uninstall -a -x --force bundler && sudo gem install bundler -v "1.15.4" ; fi
-'
 
 source ../shared/images/generate-node.sh
 source ../shared/images/generate.sh


### PR DESCRIPTION
This reverts https://github.com/circleci/circleci-images/pull/99 as it was not
correctly removing and cleaning up Bundler versions.

The Ruby has not been published in a while due to a bug with tag handling, so
this was missed before today.

If someone wants to use a specific bundler version, they should install it
themselves and use bundlers mechanisms for handling that.