### PR TITLE
Use JDK 9-slim cacerts for OpenJDK 9

### DIFF
--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -15,6 +15,17 @@ function generate_customizations() {
 
   cat <<EOF
 
+# cacerts from OpenJDK 9-slim to workaround http://bugs.java.com/view_bug.do?bug_id=8189357
+# AND https://github.com/docker-library/openjdk/issues/145
+#
+# Created by running:
+# docker run --rm openjdk:9-slim cat /etc/ssl/certs/java/cacerts | \
+#   aws s3 cp - s3://circle-downloads/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts --acl public-read
+RUN if java -fullversion 2>&1 | grep -q '"9.'; then \
+  curl --silent --show-error --location --fail --retry 3 --output /etc/ssl/certs/java/cacerts \
+       https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts; \
+ fi
+
 # Install Maven Version: $MAVEN_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz \
     https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
@@ -55,10 +66,10 @@ EOF
 ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin:$PATH"
 
 # smoke test with path
-RUN mvn -version
-RUN ant -version
-RUN gradle -version
-RUN sbt sbtVersion
+RUN mvn -version \
+  && ant -version \
+  && gradle -version \
+  && sbt sbtVersion
 
 EOF
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

OpenJDK 9 images have empty cacert files which was reported in
https://github.com/docker-library/openjdk/issues/145 and http://bugs.java.com/view_bug.do?bug_id=8189357 .

Here we use a cacert cache from `openjdk:9-slim` image that seems to be
populated correctly.
