### PR TITLE
Attempt to recover from transient build fails

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -15,7 +15,7 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
     mv composer.phar /usr/local/bin/composer
 
 # xdebug is not compatible with 7.2 yet
-RUN if [[ $(php-config --version) = 7.2* ]]; then echo "skipping xdebug, not supported"; else pecl install xdebug && docker-php-ext-enable xdebug; fi
+RUN if php-config --version | grep -q 7.2; then echo "skipping xdebug, not supported"; else pecl install xdebug && docker-php-ext-enable xdebug; fi
 
 EOF
 )

--- a/shared/images/build.sh
+++ b/shared/images/build.sh
@@ -41,7 +41,11 @@ docker pull $IMAGE_NAME || true
 if is_variant
 then
     echo "image is a variant image"
-    docker build -t $IMAGE_NAME .
+
+    # retry building for transient failures; note docker cache kicks in
+    # and this should only restart with the last failed step
+    docker build -t $IMAGE_NAME . || (sleep 2; echo "retry building $IMAGE_NAME"; docker build -t $IMAGE_NAME .)
+
     docker push $IMAGE_NAME
 
     update_aliases


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

Docker builds may fail for many transient failures (e.g. networking
blips, origin server returning 500, etc).  Here we retry the docker
build one more time.

This shouldn't add much overhead in the true failure case: Only the last
failed step would be re-run as earlier steps should be cached.

A sample transient failure is connection to pgp.mit.edu timing out in https://circleci.com/gh/circleci/circleci-images/3491 :

```
+ gpg --keyserver pgp.mit.edu --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: keyserver receive failed: No data
+ gpg --keyserver keyserver.pgp.com --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
gpg: keyserver receive failed: Connection timed out
+ gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
gpg: keyserver receive failed: Cannot assign requested address
The command '/bin/sh -c set -ex   && for key in     94AE36675C464D64BAFA68DD7434390BDBE9B9C5     FD3A5288F042B6850C66B31F09FE44734EB7990E     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1     DD8F2338BAE7501E3DD5AC78C273792F7D83545D     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8     B9AE9905FFD7803F25714661B63B535A4C206CA9     56730D5401028683275BD23C23EFEFE93C4CFFFE     77984A986EBC2AA786BC0F66B01FBB92821C587A   ; do     gpg --keyserver pgp.mit.edu --recv-keys "$key" ||     gpg --keyserver keyserver.pgp.com --recv-keys "$key" ||     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ;   done' returned a non-zero code: 2
make[1]: *** [python/images/3.7.0a2-stretch/node/publish_image] Error 2
```