### PR TITLE
Create man directory

### DIFF
--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -6,7 +6,10 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# man directory is missing in some base images
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN apt-get update \
+  && mkdir -p /usr/share/man/man1
   && apt-get install -y \
     git mercurial xvfb \
     locales sudo openssh-client ca-certificates tar gzip parallel \


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

Some images (i.e. php) use debian stretch-slim which doesn't have some
man directories causing installs to fail.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199

This hit build https://circleci.com/gh/circleci/circleci-images/3536