### PR TITLE
Parallelize expensive images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
 
   publish_python:
     <<: *publish_image
+    parallelism: 2
     environment:
       - PLATFORM: python
 
@@ -77,6 +78,7 @@ jobs:
 
   publish_php:
     <<: *publish_image
+    parallelism: 3
     environment:
       - PLATFORM: php
 
@@ -122,6 +124,7 @@ jobs:
 
   publish_buildpack-deps:
     <<: *publish_image
+    parallelism: 2
     environment:
       - PLATFORM: buildpack-deps
 

--- a/shared/images/generate.sh
+++ b/shared/images/generate.sh
@@ -13,6 +13,9 @@ INCLUDE_ALPINE=${INCLUDE_ALPINE:-false}
 
 TAG_FILTER="${TAG_FILTER:-cat}"
 
+CIRCLE_NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
+CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+
 function find_tags_and_aliases() {
   ALPINE_TAG="-e alpine"
   if [[ $INCLUDE_ALPINE == "true" ]]
@@ -26,7 +29,9 @@ function find_tags_and_aliases() {
     | grep -v $ALPINE_TAG -e 'slim' -e 'onbuild' -e windows -e wheezy -e nanoserver \
     | ${TAG_FILTER} \
     | sed 's/, /:/' \
-    | sed 's/, /,/g'
+    | sed 's/, /,/g' \
+    | sort | awk "NR % ${CIRCLE_NODE_TOTAL} == ${CIRCLE_NODE_INDEX}"
+
 }
 
 SHARED_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

PHP images take ~2 hours, buildpacks and python images over an hour.
Thus lets parallelize them