### PR TITLE
initial work: push Dockerfiles to separate GitHub repo for customer convenience

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,11 @@ jobs:
           name: git clone & cp
           command: |
             git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
-            cp -rf /tmp/dockerfiles/* circleci-dockerfiles
+            cp -rfv /tmp/dockerfiles/* circleci-dockerfiles
       # only push Dockerfiles to github on circleci-images pushes to "master" or "production"
       - run:
           name: branch control flow & git push
+          working_directory: circleci-dockerfiles
           command: |
             if [[ "$CIRCLE_BRANCH" == "production" ]]
             then
@@ -45,10 +46,9 @@ jobs:
             fi
             if [ ! -e $DOCKERFILES_BRANCH ]
             then
-              cd circleci-dockerfiles
               git add .
-              git commit --allow-empty -m "Dockerfiles from commit $CIRCLE_SHA1"
-              git push origin $DOCKERFILES_BRANCH
+              git commit --allow-empty -m "Dockerfiles from commit $CIRCLE_SHA1 (see $CIRCLE_BUILD_URL for details)"
+              git push -f origin $DOCKERFILES_BRANCH
             fi
 
   refresh_tools_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             then
               export DOCKERFILES_BRANCH=staging
             fi
-            if [ -z "$DOCKERFILES_BRANCH" ]
+            if [ ! -e $DOCKERFILES_BRANCH ]
             then
               cd circleci-dockerfiles
               git add .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,39 @@ jobs:
       - store_artifacts:
           path: /tmp/dockerfiles
           destination: Dockerfiles
+      # upload Dockerfiles to circleci-public/circleci-dockerfiles repo
+      - add_ssh_keys:
+          fingerprints:
+            - "af:0a:93:75:51:75:1f:16:90:d9:97:b1:7a:bb:f0:27"
+      - run:
+          name: git config
+          command: |
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+            git config --global user.name "$CIRCLE_USERNAME"
+      - run:
+          name: git clone & cp
+          command: |
+            git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
+            cp -rf /tmp/dockerfiles/* circleci-dockerfiles
+      # only push Dockerfiles to github on circleci-images pushes to "master" or "production"
+      - run:
+          name: branch control flow & git push
+          command: |
+            if [[ "$CIRCLE_BRANCH" == "production" ]]
+            then
+              export DOCKERFILES_BRANCH=master
+            fi
+            if [[ "$CIRCLE_BRANCH" == "master" ]]
+            then
+              export DOCKERFILES_BRANCH=staging
+            fi
+            if [ -z "$DOCKERFILES_BRANCH" ]
+            then
+              cd circleci-dockerfiles
+              git add .
+              git commit -m "Dockerfiles from commit $CIRCLE_SHA1"
+              git push origin $DOCKERFILES_BRANCH
+            fi
 
   refresh_tools_cache:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             then
               cd circleci-dockerfiles
               git add .
-              git commit -m "Dockerfiles from commit $CIRCLE_SHA1"
+              git commit --allow-empty -m "Dockerfiles from commit $CIRCLE_SHA1"
               git push origin $DOCKERFILES_BRANCH
             fi
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,7 @@ https://hub.docker.com/explore/
 CircleCI supported images are here:
 https://hub.docker.com/r/circleci/
 
-To view the Dockerfiles for CircleCI images, check the artifacts tab of the latest green job for this repo:
-https://circleci.com/gh/circleci/circleci-images/tree/master
-
-The Dockerfiles aren't available on Docker Hub.  Currently, they can only be uploaded with Docker Hub's automated builder.
-
-
+To view the Dockerfiles for CircleCI images, visit the [CircleCI-Public/circleci-dockerfiles](https://github.com/circleci-public/circleci-dockerfiles) repository.
 
 # How to add a bundle with images
 


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

- there's currently no easy way for customers to view dockerfiles for our convenience images
- sending them into the build artifacts for this repo is needlessly complicated
- we can't work with docker hub's automated builds with integrated dockerfiles for a variety of reasons
- i set up a [separate repository](https://github.com/circleci-public/circleci-dockerfiles) solely to store dockerfiles for our convenience images.
- (if everything had worked on first push, there wouldn't be anything in that repo yet, but, since i messed up some conditionals before [this commit](https://github.com/circleci/circleci-images/pull/127/commits/dc12426f5fab795286ea8218d778bc8867e22cb0), [circleci-dockerfiles](https://github.com/circleci-public/circleci-dockerfiles) now nicely demonstrates the intended functionality...)
<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
- this PR adds code to the config.yml's `generate_dockerfiles` job to automatically take the assembled Dockerfile build artifacts and push them to the circleci-dockerfiles repository
- its master branch will track pushes to this repository's production branch, and a staging branch will track pushes to this repository's master branch
- if folks are happy with this approach, we can also modify these images' default READMEs that get pushed to Docker Hub to include links to the [circleci-dockerfiles repository](https://github.com/circleci-public/circleci-dockerfiles), which will also satisfy [this PR](https://github.com/circleci/circleci-images/pull/89) and then some