### PR TITLE
Update Dockerfile-browsers.template

### DIFF
--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -38,16 +38,16 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
   && rm -rf /tmp/firefox.deb \
   && firefox --version
 
-# install geckodriver
+# install geckodriver—disabling this temporarily, we will likely want this code in the future, but until we're ready to upgrade our version of firefox to 53+, geckodriver wont' be compatible...
 
-RUN export GECKODRIVER_LATEST_RELEASE_URL=$(curl https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".assets[] | select(.name | test(\"linux64\")) | .browser_download_url") \
-      && curl --silent --show-error --location --fail --retry 3 --output /tmp/geckodriver_linux64.tar.gz "$GECKODRIVER_LATEST_RELEASE_URL" \
-      && cd /tmp \
-      && tar xf geckodriver_linux64.tar.gz \
-      && rm -rf geckodriver_linux64.tar.gz \
-      && sudo mv geckodriver /usr/local/bin/geckodriver \
-      && sudo chmod +x /usr/local/bin/geckodriver \
-      && geckodriver --version
+# RUN export GECKODRIVER_LATEST_RELEASE_URL=$(curl https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".assets[] | select(.name | test(\"linux64\")) | .browser_download_url") \
+#      && curl --silent --show-error --location --fail --retry 3 --output /tmp/geckodriver_linux64.tar.gz "$GECKODRIVER_LATEST_RELEASE_URL" \
+#      && cd /tmp \
+#      && tar xf geckodriver_linux64.tar.gz \
+#      && rm -rf geckodriver_linux64.tar.gz \
+#      && sudo mv geckodriver /usr/local/bin/geckodriver \
+#      && sudo chmod +x /usr/local/bin/geckodriver \
+#      && geckodriver --version
 
 # install chrome
 


### PR DESCRIPTION
temporarily remove geckodriver until we're ready to upgrade firefox to at least v53

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

I added geckodriver to our browsers images in response to an issue @levlaz opened but didn't realize that geckodriver requires Firefox v53+.... rather than suddenly upgrading Firefox across all our browser images, which could cause other issues, it seems better to remove geckodriver for now and add it back in when we're ready to bump Firefox (which is why i'm just commenting out the geckodriver code rather than removing it outright)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
