### PR TITLE
Find the latest production release of SBT

### DIFF
--- a/shared/images/refresh-tools-cache
+++ b/shared/images/refresh-tools-cache
@@ -43,5 +43,6 @@ PHANTOMJS_VERSION=$(curl --location --fail --retry 3  https://api.github.com/rep
 refresh_cache phantomjs-latest.tar.bz2 \
 	"https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"
 
+# need to ignore Release candidate and milestone releases to get stable ones
 refresh_cache sbt-latest.tgz \
-	$(curl --location --fail --retry 3 https://api.github.com/repos/sbt/sbt/releases/latest  | grep browser_download_url | grep 'tgz"' | grep -o -e 'https.*.tgz')
+	$(curl --location --fail --retry 3 https://api.github.com/repos/sbt/sbt/releases | grep browser_download_url | grep 'tgz"' | grep -o -e 'https.*.tgz' | grep -v -e '-RC' -e '-M' | head -n1)


### PR DESCRIPTION
### Checklist
- [ ] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [ ] I've updated the documentation if necessary.

### Motivation and Context

SBT download is failing https://circleci.com/gh/circleci/circleci-images/4072 because the latest SBT release is an RC release without any binary tarballs included: https://api.github.com/repos/sbt/sbt/releases/8938949 .

This instead attempts to find the most recent production release with binary tarballs that's not an RC or a milestone release.  Sadly, I cannot think of a better way for finding "production" releases.