### PR TITLE
Update refresh-tools-cache

### DIFF
--- a/shared/images/refresh-tools-cache
+++ b/shared/images/refresh-tools-cache
@@ -39,9 +39,13 @@ refresh_cache docker-compose-latest \
 refresh_cache dockerize-latest.tar.gz \
 	$(curl --location --fail --retry 3 https://api.github.com/repos/jwilder/dockerize/releases/latest | jq -r '.assets[] | select(.name | startswith("dockerize-linux-amd64")) | .browser_download_url')
 
-PHANTOMJS_VERSION=$(curl --location --fail --retry 3  https://api.github.com/repos/ariya/phantomjs/tags | jq -r '.[0].name')
+LATEST_PHANTOMJS_URL=$(curl --location --fail --retry 3  \
+	https://api.bitbucket.org/2.0/repositories/ariya/phantomjs/downloads | \
+	jq '[.values[].links.self.href]' | jq "map(select(contains(\"beta\") | not))" | \
+	jq "map(select(contains(\"x86_64\")))" | jq '.[0]')
+
 refresh_cache phantomjs-latest.tar.bz2 \
-	"https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
+	"$(LATEST_PHANTOMJS_URL)"
 
 # need to ignore Release candidate and milestone releases to get stable ones
 refresh_cache sbt-latest.tgz \


### PR DESCRIPTION
don't hardcode phantomjs version anymore, @heug & i wrote some jq stuff to parse the bitbucket api for latest release instead of the github api (since bitbucket downloads don't seem to precisely track github releases at the moment)

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [ ] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to <issue>.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
