### PR TITLE
Correct some typos in the README template

### DIFF
--- a/shared/images/README-basic.template
+++ b/shared/images/README-basic.template
@@ -11,7 +11,7 @@ However, we frequently found them lacking some tools making them appropriate for
 3. Variants for common use cases, e.g. images with common browsers installed and configured to run in a containized environment
 4. Use a non-root user (namely `circleci`) by default.  Many applications refuse to run as run (e.g. `chrome`) or their behavior differs when run as root (e.g. `tar` file ownership behavior)
 
-Aiming to have CircleCI extended images ease adoption of Docker and CircleCI.  Once users are successful, we encourage users to build and customize their images to suite their individual project needs.
+We aim to have CircleCI extended images ease adoption of Docker and CircleCI.  Once users are successful, we encourage users to build and customize their images to suit their individual project needs.
 
 # Notable Variants
 


### PR DESCRIPTION
### Checklist

- [x] I've updated the documentation if necessary.

### Motivation and Context

While reading the documentation on the dockerhub for node I noticed some grammatical bits that could be cleaned up.

### Description

Tightened up the wording, changed `suite` to `suit`.
