### PR TITLE
Only edit the real mongo entrypoint file

### DIFF
--- a/mongo/resources/Dockerfile-ram.template
+++ b/mongo/resources/Dockerfile-ram.template
@@ -1,9 +1,8 @@
 FROM {{BASE_IMAGE}}
 
-# mongo images moved entrypoint modify both places but don't fail if one isn't present
-# TODO: Update the entrypoint file deterministically
-RUN sed -i '/exec "$@"/i mkdir \/dev\/shm\/mongo' /entrypoint.sh || \
-      sed -i '/exec "$@"/i mkdir \/dev\/shm\/mongo' /usr/local/bin/docker-entrypoint.sh || \
-      true
+# The ENTRYPOINT for mongo is at /usr/local/bin/docker-entrypoint.sh, but pre-3.6 images also
+# include a symlink from /entrypoint.sh to that script. So, it's only necessary to update the real
+# entrypoint file. This comment can be removed once all pre-3.6 mongo images are gone.
+RUN sed -i '/exec "$@"/i mkdir \/dev\/shm\/mongo' /usr/local/bin/docker-entrypoint.sh
 
 CMD ["mongod", "--nojournal", "--noprealloc", "--smallfiles", "--dbpath=/dev/shm/mongo"]


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to and fixes #143 . See that issue for a full description of the bug. However, this PR is able to fix the issue in an even simpler way than described in the issue, while also resolving an outstanding "TODO" in the existing Dockerfile.

I've tested this by building and running all of the `-ram` images (3.0, 3.2, 3.4, 3.6) locally. Without this PR, all of the `-ram` images except 3.6 crash when they are run.

### Description

In `mongo:3.6`, there is only a file at `/usr/local/bin/docker-entrypoint.sh`. In earlier versions, there is also a symlink at `/entrypoint.sh`.

Previously, the attempt to edit the symlink without `sed`'s `--follow-symlinks` option was causing the symlink to be rewritten as a real file.

By now ignoring the symlink and only editing the real file. both 3.6 and pre-3.6 versions are cleanly supported.