### PR TITLE
Ensure that libglu exists for Flutter test

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -39,7 +39,10 @@ ARG android_home=/opt/android/sdk
 # SHA-256 444e22ce8ca0f67353bda4b85175ed3731cae3ffa695ca18119cbacef1c1bea0
 
 RUN sudo apt-get update && \
-    sudo apt-get install --yes xvfb gcc-multilib lib32z1 lib32stdc++6 build-essential libcurl4-openssl-dev
+    sudo apt-get install --yes \
+        xvfb gcc-multilib lib32z1 lib32stdc++6 build-essential \
+        libcurl4-openssl-dev libglu1-mesa libxi-dev libxmu-dev \
+        libglu1-mesa-dev
 
 # Install Ruby
 RUN cd /tmp && wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz && \


### PR DESCRIPTION

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- ~~[ ] I've updated the documentation if necessary.~~

### Motivation and Context

Refs flutter/flutter#14239

Verified by successfully running `flutter test` inside of the modified circleci/android:api-27-alpha Docker image

### Description

Install common OpenGL libraries so that [Flutter](https://flutter.io) can run unit tests in headless mode under CircleCI's Android images
