### PR TITLE
Re-introduce xdebug

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -14,8 +14,7 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
-# xdebug is not compatible with 7.2 yet
-RUN if php-config --version | grep -q 7.2; then echo "skipping xdebug, not supported"; else pecl install xdebug && docker-php-ext-enable xdebug; fi
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 EOF
 )


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to https://github.com/circleci/circleci-images/issues/148

Xdebug should be compatible with 7.2 now.