### PR TITLE
PHP5 no longer supports xdebug

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -14,7 +14,7 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
-RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN (pecl install xdebug && docker-php-ext-enable xdebug) || exit 0
 
 EOF
 )


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.
