### PR TITLE
Install openjfx

### DIFF
--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -58,6 +58,9 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz
   && rm /tmp/sbt.tgz \
   && /opt/sbt/bin/sbt sbtVersion
 
+# Install openjfx
+RUN apt-get install -y --no-install-recommends openjfx
+
 EOF
 
   # Modify path but don't inject builder path in there!


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.

### Motivation and Context

This PR relates to https://github.com/circleci/circleci-images/issues/171

Installing openjfx in our openjdk images.