### PR TITLE
ln -s /home/circleci /home/ubuntu

### DIFF
--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -69,7 +69,9 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
 RUN groupadd --gid 3434 circleci \
   && useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci \
   && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci \
-  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep \
+  && ln -s /home/circleci /home/ubuntu
+  # symlink these two home dirs for 1.0 -> 2.0 compatibility
 
 # BEGIN IMAGE CUSTOMIZATIONS
 # END IMAGE CUSTOMIZATIONS


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

I am adding a symlink from the existing /home/circleci to /home/ubuntu to better support migrating projects from 1.0 to 2.0. Many projects currently rely on this specific notation for a plethora of reasons, though they all boil down to not changing existing configuration files to account for the change.