### PR TITLE
Pin Chrome to 64.0.3282.186-1 to address browser testing issues

### DIFF
--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -50,8 +50,10 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
 #      && geckodriver --version
 
 # install chrome
+# Note: Revert back to https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+# after browser testing works in google-chrome-stable 65.0.x.y
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_64.0.3282.186-1_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
       && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

Headless browser testing isn't working with Chrome 65.0.3325.146-1 so we're reverting and pinning to 64.0.3282.186-1.