### PR TITLE
Ensure circle-android is runnable

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -8,6 +8,7 @@ LABEL maintainer="marc@circleci.com"
 # Initial Command run as `root`.
 
 ADD https://raw.githubusercontent.com/circleci/circleci-images/master/android/bin/circle-android /bin/circle-android
+RUN chmod +rx /bin/circle-android
 
 # Skip the first line of the Dockerfile template (FROM ${BASE})
 syscmd(`tail -n +2 ../shared/images/Dockerfile-basic.template')


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This makes the circle-android program executable. It's required due to changes in the way the program is copied into the image.

I've tested to confirm that images built with this change do indeed have the circle-android binary runnable as the circleci user.