### PR TITLE
Switch to nightly image builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ workflows:
   build_test_deploy:
     triggers:
       - schedule:
-          cron: "0 0 * * 0"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
I propose that production images should be built nightly instead of only on Sundays. I actually thought this was what we were doing.

Issue #180 is exactly why images should be built more often rather than less often. Security releases not only happen for multiple supported releases of a single language such as Ruby, but then across many of the languages we support and any dependencies in those images that we may not be aware of.