### PR TITLE
Add zip to php image

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -16,6 +16,9 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
 
 RUN (pecl install xdebug || pecl install xdebug-2.5.5) && docker-php-ext-enable xdebug
 
+# Install php-zip
+RUN apt-get install zlib1g-dev && docker-php-ext-install zip
+
 EOF
 )
 


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

With the most popular PHP frameworks + PHPUnit, the zip extension is unavoidable. Many people struggle to figure it out, making it harder to get PHP devs into CI (I teach this topic and use CircleCI in my examples).

Examples of confused users:
https://discuss.circleci.com/t/cant-install-ext-zip-package-on-circleci-2-0/16397/6
https://laracasts.com/discuss/channels/laravel/zip-php-extension-problem-in-ubuntu-php7

### Description

Added the same 2 commands that I added to my circle.yml in order to get my build to pass on CircleCI.
