### PR TITLE
Revert Chrome download to current release.

### DIFF
--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -51,7 +51,7 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
 
 # install chrome
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_64.0.3282.140.deb \
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
       && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -51,7 +51,7 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
 
 # install chrome
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_current_amd64.deb \
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_64.0.3282.140.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
       && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -50,10 +50,8 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
 #      && geckodriver --version
 
 # install chrome
-# Note: Revert back to https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-# after browser testing works in google-chrome-stable 65.0.x.y
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_64.0.3282.186-1_amd64.deb \
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_current_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
       && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \


### PR DESCRIPTION
The version of Chrome that we locked builds to is no longer hosted by Google. This is causing builds to fail. Switching to the current release.