### PR TITLE
Update Dockerfile-browsers.template

### DIFF
--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -68,7 +68,7 @@ RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chrome
       && chromedriver --version
       
 # install libgconf-2-4 manually since chrome no longer pulls it in automatically
-RUN sudo apt-get -y install libgconf-2-4
+RUN sudo apt-get install -y libgconf-2-4
 
 # start xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -66,6 +66,9 @@ RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chrome
       && sudo mv chromedriver /usr/local/bin/chromedriver \
       && sudo chmod +x /usr/local/bin/chromedriver \
       && chromedriver --version
+      
+# install libgconf-2-4 manually since chrome no longer pulls it in automatically
+RUN sudo apt-get install libgconf-2-4
 
 # start xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -68,7 +68,7 @@ RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chrome
       && chromedriver --version
       
 # install libgconf-2-4 manually since chrome no longer pulls it in automatically
-RUN sudo apt-get install libgconf-2-4
+RUN sudo apt-get -y install libgconf-2-4
 
 # start xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99


### PR DESCRIPTION
install libgconf-2-4 in `-browsers` images manually since chrome no longer pulls it in automatically

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation, Context, and Description

manually add libgconf-2-4 to `-browsers` images since chrome no longer pulls it in automatically