### PR TITLE
Add dep to golang image

### DIFF
--- a/golang/generate-images
+++ b/golang/generate-images
@@ -4,4 +4,8 @@ NAME="Go (golang)"
 BASE_REPO=golang
 VARIANTS=(browsers)
 
+IMAGE_CUSTOMIZATIONS='
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | INSTALL_DIRECTORY=/usr/local/bin sh
+'
+
 source ../shared/images/generate.sh


### PR DESCRIPTION
### Motivation and Context

https://github.com/golang/dep has been widely adopted as the most common way of managing `vendor` in Go. Including it in the circleci image allows users to download dependencies (if they are not already checked into git) or validate that PRs have updated `vendor` correctly according to the contents of `Gopkg.toml/lock`.

### Description

Add another `RUN` line to download `dep`.
