### PR TITLE
Fix buildpack-deps image btrfs package.

### DIFF
--- a/buildpack-deps/resources/Dockerfile-dind.template
+++ b/buildpack-deps/resources/Dockerfile-dind.template
@@ -7,15 +7,14 @@ FROM {{BASE_IMAGE}}
 # docker installations command expect to run as root
 USER root
 
-RUN apt-get update && apt-get install -y \
-	iptables \
-	xz-utils
-
 #  The package `btrfs-progs` has replaced `btrfs-tools` in newer distros. 
 #  We'll try both for now but after older distros like Ubuntu 16.04 (Xenial), 
 #  and Debian Stretch drop off the tag lists from upstream, we should just 
 #  install `btrfs-progs`.
-RUN if ! apt-get install -y btrfs-tools; then  apt-get install -y btrfs-progs; fi
+RUN apt-get update && apt-get install -y \
+		iptables \
+		xz-utils &&
+	if ! apt-get install -y btrfs-tools; then  apt-get install -y btrfs-progs; fi
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 RUN set -x \

--- a/buildpack-deps/resources/Dockerfile-dind.template
+++ b/buildpack-deps/resources/Dockerfile-dind.template
@@ -7,11 +7,15 @@ FROM {{BASE_IMAGE}}
 # docker installations command expect to run as root
 USER root
 
-RUN apt-get update \
-    && apt-get install -y \
-             iptables \
-	     btrfs-tools \
-	     xz-utils
+RUN apt-get update && apt-get install -y \
+	iptables \
+	xz-utils
+
+#  The package `btrfs-progs` has replaced `btrfs-tools` in newer distros. 
+#  We'll try both for now but after older distros like Ubuntu 16.04 (Xenial), 
+#  and Debian Stretch drop off the tag lists from upstream, we should just 
+#  install `btrfs-progs`.
+RUN apt-get install -y btrfs-tools || apt-get install -y btrfs-progs
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 RUN set -x \

--- a/buildpack-deps/resources/Dockerfile-dind.template
+++ b/buildpack-deps/resources/Dockerfile-dind.template
@@ -13,7 +13,7 @@ USER root
 #  install `btrfs-progs`.
 RUN apt-get update && apt-get install -y \
 		iptables \
-		xz-utils &&
+		xz-utils && \
 	if ! apt-get install -y btrfs-tools; then  apt-get install -y btrfs-progs; fi
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box

--- a/buildpack-deps/resources/Dockerfile-dind.template
+++ b/buildpack-deps/resources/Dockerfile-dind.template
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 #  We'll try both for now but after older distros like Ubuntu 16.04 (Xenial), 
 #  and Debian Stretch drop off the tag lists from upstream, we should just 
 #  install `btrfs-progs`.
-RUN apt-get install -y btrfs-tools || apt-get install -y btrfs-progs
+RUN if ! apt-get install -y btrfs-tools; then  apt-get install -y btrfs-progs; fi
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 RUN set -x \


### PR DESCRIPTION
`buildpack-deps` images are failing. In trying to locate the error, I noticed a bunch of errors about installing the `btrfs-tools` package.

In newer distro releases, that package has been replaced by `btrfs-progs`. Some distros such as Ubuntu 18.04 has both packages with the formal being a meta transitional package. That works. Debian Sid has no such thing though so installing `btrfs-tools` is failing.

I made a new RUN command try try installing one or then the other. This should help with the transition period. Once we're no longer building the old distros, we can remove the installation of `btrfs-tools` all together.

My only concern, is the way Docker layers are cached going to affect this at all? For example, could the RUN command install `btrfs-progs` and get cached, and then when building an older image, that cached layer with the wrong package name gets used? Is that possible or am I thinking too much into it?