### PR TITLE
Add android 28 platform

### DIFF
--- a/android/generate-images
+++ b/android/generate-images
@@ -17,7 +17,7 @@ function generate_dockerfile {
   echo "${dockerfile_path}"
 }
 
-for API in 23 24 25 26 27; do
+for API in 23 24 25 26 27 28; do
   echo Generating Android ${API} Dockerfiles
 
   tag=api-${API}-alpha


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Description
Adds an `android-28` image for targeting Android P (the [APIs are final as of today](https://android-developers.googleblog.com/2018/06/android-p-beta-2-and-final-apis.html))
