### PR TITLE
Postgres: remove executable flag from postgis init so that the entrypoint sources it, fixes #211

### DIFF
--- a/postgres/resources/Dockerfile-postgis.template
+++ b/postgres/resources/Dockerfile-postgis.template
@@ -63,4 +63,4 @@ RUN if which apt-get > /dev/null ; then \
 ADD https://raw.githubusercontent.com/appropriate/docker-postgis/master/initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh 
 ADD https://raw.githubusercontent.com/appropriate/docker-postgis/master/update-postgis.sh /usr/local/bin/update-postgis.sh
 
-RUN chmod +rx /docker-entrypoint-initdb.d/postgis.sh /usr/local/bin/update-postgis.sh
+RUN chmod +r /docker-entrypoint-initdb.d/postgis.sh && chmod +rx /usr/local/bin/update-postgis.sh


### PR DESCRIPTION
Fixes #211.

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to https://github.com/circleci/circleci-images/issues/211.

The execution method of additional scripts in the Postgres entrypoint was changed, executable scripts are now executed in a subshell instead of sourcing them. This leads to the environment variable `psql` not being visible.
Non-executable scripts on the other hand get sourced.

See also:
https://github.com/docker-library/postgres/pull/452

### Description

The change makes the additional script non-executable so that the entrypoint sources it instead of executing it.