### PR TITLE
Add Node variant to Go bundle.

### DIFF
--- a/golang/generate-images
+++ b/golang/generate-images
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-NAME="Go (golang)"
+NAME="Go (Golang)"
 BASE_REPO=golang
-VARIANTS=(browsers)
+VARIANTS=(browsers node node-browsers)
 
 IMAGE_CUSTOMIZATIONS='
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | INSTALL_DIRECTORY=/usr/local/bin sh
 '
 
+source ../shared/images/generate-node.sh
 source ../shared/images/generate.sh


### PR DESCRIPTION
Adding the Node.js variant to the Go bundle. There's no reason that only a few language images shouldn't have it. Consistency is likely best here.