### PR TITLE
add intl and zip to PHP images issue 9 in public

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -14,7 +14,13 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
+# Install XDebug
 RUN (pecl install xdebug || pecl install xdebug-2.5.5) && docker-php-ext-enable xdebug
+
+# Install common extensions
+RUN apt install -y libicu-dev zlib1g-dev
+RUN docker-php-ext-configure intl && docker-php-ext-install intl
+RUN docker-php-ext-install zip
 
 EOF
 )


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to https://github.com/CircleCI-Public/circleci-dockerfiles/issues/9.

Many modern PHP tools expect zip and intl extensions.  Our docs and users are having to run these installs during CI/CD which is slowing them down, and costing us extra compute time/resources.
docker 
<!--- Please describe in detail how you tested your changes. --->
```
$ cd php/images/7.2.7-apache-stretch/
$ docker build . -t php-test
Successfully built 3e2acf650f6b
circleci@c2183dd5a6ae:/var/www/html$ php -m | grep 'intl\|zip'
intl
zip
```

### Description
This adds additional `docker-php-ext-` commands to install `zip` and `intl` modules.  Additionally runs a apt-get install to install the icu and zip libraries needed.
