### PR TITLE
Pin python image used in builds to 3.6.6 as aws CLi does not yet supp…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
 
   refresh_tools_cache:
     docker:
-      - image: circleci/python:latest
+      - image: circleci/python:3.6.6 # aws cli dependenncy pyaml does not yet support 3.7 - https://github.com/aws/aws-cli/issues/3427
     steps:
       - checkout
       - run: sudo pip install awscli==1.14.17


### PR DESCRIPTION
Fixes compatibility with python 3.7 by pinning circleci config to use 3.6.6 

See https://github.com/aws/aws-cli/issues/3427 and https://circleci.com/gh/circleci/circleci-images/8162
