### PR TITLE
Run "DynamoDB Local" on CircleCI 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUNDLES = \
   android node python ruby golang php \
-  postgres mariadb mysql mongo elixir \
+  postgres mariadb mysql mongo dynamodb elixir \
   jruby clojure openjdk buildpack-deps redis rust
 
 images: $(foreach b, $(BUNDLES), $(b)/generate_images)

--- a/dynamodb/generate-images
+++ b/dynamodb/generate-images
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+NAME=DynamoDB
+BASE_REPO=openjdk
+VARIANTS=()
+
+source ../shared/images/generate.sh

--- a/dynamodb/resources/Dockerfile-basic.template
+++ b/dynamodb/resources/Dockerfile-basic.template
@@ -1,0 +1,22 @@
+FROM {{BASE_IMAGE}}
+
+# It's DynamoDB, in Docker!
+#
+# Check for details on how to run DynamoDB locally.:
+#
+# http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
+#
+# This Dockerfile essentially replicates those instructions.
+
+# Create our main application folder.
+RUN mkdir -p opt/dynamodb
+WORKDIR /opt/dynamodb
+
+# Download and unpack dynamodb.
+RUN wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -q -O - | tar -xz
+
+# The entrypoint is the dynamodb jar.
+ENTRYPOINT ["java", "-Xmx1G", "-jar", "DynamoDBLocal.jar"]
+
+# Default port for "DynamoDB Local" is 8000.
+EXPOSE 8000


### PR DESCRIPTION
### Changes

	new file:   dynamodb/generate-images
	new file:   dynamodb/resources/Dockerfile-basic.template
        changed: Makefile

### Checklist

- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

I want to run [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) inside CircleCI 2.0 so that my tests may hit a "local" deployment of DynamoDB instead of a remote copy.

### Description

Add a new image for running DynamoDB inside CircleCI 2.0

References:

 - https://russell.ballestrini.net/running-dynamodb-local-service-container-on-circleci-2/
 - https://github.com/dwmkerr/docker-dynamodb

