### PR TITLE
Properly extract the Android NDK from the downloaded archive

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -75,7 +75,7 @@ RUN sudo mkdir -p ${android_ndk_home} && \
     sudo chown -R circleci:circleci ${android_ndk_home} && \
     curl --silent --show-error --location --fail --retry 3 --output  /tmp/${ndk_version} https://dl.google.com/android/repository/${ndk_version} && \
     unzip -q /tmp/${ndk_version} -d ${android_ndk_home} && \
-    mv "${android_ndk_home}/${ndk_version}/*" "${android_ndk_home}/" && rmdir "${android_ndk_home}/${ndk_version}" && \
+    mv ${android_ndk_home}/${ndk_version}/* ${android_ndk_home}/ && rmdir ${android_ndk_home}/${ndk_version} && \
     rm /tmp/${ndk_version}
 
 # Set environmental variables

--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -75,6 +75,7 @@ RUN sudo mkdir -p ${android_ndk_home} && \
     sudo chown -R circleci:circleci ${android_ndk_home} && \
     curl --silent --show-error --location --fail --retry 3 --output  /tmp/${ndk_version} https://dl.google.com/android/repository/${ndk_version} && \
     unzip -q /tmp/${ndk_version} -d ${android_ndk_home} && \
+    mv "${android_ndk_home}/${ndk_version}/*" "${android_ndk_home}/" && rmdir "${android_ndk_home}/${ndk_version}" && \
     rm /tmp/${ndk_version}
 
 # Set environmental variables


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to #228 - the `Android NDK` is not properly extracted. The build process expects to find the NDK tools directly inside `ANDROID_NDK_HOME` but the extract process puts them in a subdirectory of `ANDROID_NDK_HOME`.

Before I made this change all my builds (of an android project) were failing with an `NDK is missing a "platforms" directory.` message. After I added a job step that manually copies the content of the ndk subdirectory to the ndk directory itself all build were successful.

### Description
 The added support for `Android NDK` relies on a downloaded `.zip` file that is extracted and its content used for NDK builds. The problem in the mentioned issue is that the extracted content is actually unzipped in a subdirectory inside the `ANDROID_NDK_HOME`. E.g. if `ANDROID_NDK_HOME` is `/opt/android/ndk` then the `NDK` tools are unzipped inside `/opt/android/ndk/android-ndk-r17b/`. 

This change moves the tools one level up so they can be properly found inside `/opt/android/ndk/` (a.k.a. `ANDROID_NDK_HOME`) where the build tools expect them.

**Note:** It's probably much better to achieve the same with the extract tool itself (`unzip` or `tar`) but I can't find a straight-forward way yet. At least not with unzip.
