### PR TITLE
PR to Issue 234 on top of changes from freespirit:patch-1

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -71,12 +71,13 @@ RUN sudo mkdir -p ${android_home} && \
     rm /tmp/${sdk_version}
 
 # Download and install Android NDK
+ARG path_to_extracted_ndk=/tmp/extracted_ndk
 RUN sudo mkdir -p ${android_ndk_home} && \
     sudo chown -R circleci:circleci ${android_ndk_home} && \
     curl --silent --show-error --location --fail --retry 3 --output  /tmp/${ndk_version} https://dl.google.com/android/repository/${ndk_version} && \
-    unzip -q /tmp/${ndk_version} -d ${android_ndk_home} && \
-    mv ${android_ndk_home}/${ndk_version}/* ${android_ndk_home}/ && rmdir ${android_ndk_home}/${ndk_version} && \
-    rm /tmp/${ndk_version}
+    unzip -q /tmp/${ndk_version} -d ${path_to_extracted_ndk} && \
+    mv ${path_to_extracted_ndk}/*/* ${android_ndk_home}/ && \
+    rm /tmp/${ndk_version} && rm -r ${path_to_extracted_ndk}
 
 # Set environmental variables
 ENV ANDROID_HOME ${android_home}


### PR DESCRIPTION
- corrected and changed the way, the subdirectory of the extracted ndk zipfile is moved to ANDROID_NDK_HOME

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to issue 234.

<!--- Why is this change required? What problem does it solve? -->
The subdirectory path of the extracted ndk wasn't correctly used and leads to non functional ndk installation.
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
