### PR TITLE
git diff logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,21 @@ jobs:
       - run:
           name: Docker Login
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+      - run:
+          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified
+          command: |
+            # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
+
+            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+            echo "Commit range: "$COMMIT_RANGE"
+
+            git diff $COMMIT_RANGE --name-status
+
+            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") ]]; then
+              circleci step halt
+            fi
+
       - run:
           name: Build and Publish Images
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
       - run:
           name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified
           command: |
+            set -u
             # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
 
             COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

currently, we rebuild all images on any commit to any part of the repo. we can save ourselves a lot of time if we only build images when code that touches them has changed. because the repos are interconnected, this _isn't_ as simple as simply `grep`'ing the `git diff` for the name of the repo—but it's _almost_ that simple.

### Description

for each `publish_image` job, check the `git diff` for the current commit & only proceed with the job if:

- the directory for that image itself has changed
- the `/shared` directory has changed
- the Makefile has changed

(list could arguably be expanded to include the config.yml file itself, but that would also have drawbacks)