### PR TITLE
only build images when necessary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
             # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
 
             COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
-            echo "Commit range: "$COMMIT_RANGE"
+            echo "Commit range: $COMMIT_RANGE"
 
             git diff $COMMIT_RANGE --name-status
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,9 +275,8 @@ workflows:
           filters:
             branches:
               only:
+                - staging
                 - master
-                - production
-                - parallel
       - refresh_tools_cache:
           requires:
             - generate_dockerfiles


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to #243 

### Description

rather than always building all images on any commit (to branches that are part of the build/publish control flow), only build when the requisite `$PLATFORM`, or the makefile, or any of the `/shared` shell scripts, are modified.

it's working on staging ! https://circleci.com/workflow-run/a9943633-4e57-43c2-9647-ecff459e36a2