### PR TITLE
always build all images on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       - run:
-          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified
+          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
           command: |
             set -u
             # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
@@ -122,8 +122,8 @@ jobs:
             echo "Commit range: $COMMIT_RANGE"
 
             git diff $COMMIT_RANGE --name-status
-
-            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") ]]; then
+            
+            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
               circleci step halt
             fi
 


### PR DESCRIPTION
we probably want to build all images always on master, even if no files related directly to a particular `$PLATFORM` have been modified

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Description

add a branch check to our `git diff` logic