### PR TITLE
Fix the failing builds by setting OPENSSL_CONF to anything

### DIFF
--- a/shared/images/Dockerfile-browsers-legacy.template
+++ b/shared/images/Dockerfile-browsers-legacy.template
@@ -15,6 +15,8 @@ RUN if grep -q Debian /etc/os-release && grep -q jessie /etc/os-release; then \
     sudo apt-get update; sudo apt-get install -y openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk openjdk-8-jdk-headless \
   ; fi
 
+ENV OPENSSL_CONF /
+
 ## install phantomjs
 #
 RUN PHANTOMJS_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/phantomjs-latest.tar.bz2" \


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to failing builds we're seeing with regards to phantomjs.