### PR TITLE
Add Android SDK Build Tools 28.0.3

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -97,7 +97,8 @@ RUN sdkmanager \
   "build-tools;27.0.1" \
   "build-tools;27.0.2" \
   "build-tools;27.0.3" \
-  "build-tools;28.0.0"
+  "build-tools;28.0.0" \
+  "build-tools;28.0.3"
 
 # API_LEVEL string gets replaced by m4
 RUN sdkmanager "platforms;android-API_LEVEL"


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context
Version 28.0.3 is required for Android Gradle Plugin 3.2.x.

Closes CircleCI-Public/circleci-dockerfiles#13.