### PR TITLE
Updating Node variants to current LTS, 10.

### DIFF
--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -46,7 +46,7 @@ function generate_node_browser_legacy_variant() {
 }
 
 mkdir -p resources
-generate_node_variant "carbon$" > resources/Dockerfile-node.template
+generate_node_variant "lts$" > resources/Dockerfile-node.template
 generate_node_browser_variant > resources/Dockerfile-node-browsers.template
 generate_node_browser_legacy_variant > resources/Dockerfile-node-browsers-legacy.template
 


### PR DESCRIPTION
The Node LTS has been bumped from Node.js v8 to v10. We're a few weeks behind on this but this completes that update on our end.