### PR TITLE
Remove the second FROM line that is breaking images

### DIFF
--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -10,6 +10,9 @@ function generate_node_variant() {
 
 FROM {{BASE_IMAGE}}
 
+# Verify the circleci user exists before proceeding
+RUN whoami
+
 # node installations command expect to run as root
 USER root
 EOF

--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -20,7 +20,7 @@ EOF
 
   NODE_DOCKERFILE_URL="https://raw.githubusercontent.com/nodejs/docker-node/${NODE_GIT_COMMIT}/${NODE_DIRECTORY}/Dockerfile"
   echo "## Using node installation from $NODE_DOCKERFILE_URL"
-  curl --silent --location --fail --retry 3 "$NODE_DOCKERFILE_URL" | grep -v -e '^FROM buildpack-deps:jessie' -e '^CMD'
+  curl --silent --location --fail --retry 3 "$NODE_DOCKERFILE_URL" | grep -v -e '^FROM buildpack-deps' -e '^CMD'
 
   echo ''
   echo '# Basic smoke test'


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to an issue where certain images are extending the wrong base image.