### PR TITLE
Fall back to curl when wget is missing

### DIFF
--- a/dynamodb/resources/Dockerfile-basic.template
+++ b/dynamodb/resources/Dockerfile-basic.template
@@ -13,7 +13,7 @@ RUN mkdir -p opt/dynamodb
 WORKDIR /opt/dynamodb
 
 # Download and unpack dynamodb.
-RUN wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -q -O - | tar -xz
+RUN wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -q -O - | tar -xz || curl -L http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz | tar xz
 
 # The entrypoint is the dynamodb jar.
 ENTRYPOINT ["java", "-Xmx1G", "-jar", "DynamoDBLocal.jar"]


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to an issue where newer versions of Dynamodb are failing to build because wget is missing.