### PR TITLE
Exclude oraclelinux from the openjdk build

### DIFF
--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -4,7 +4,7 @@ NAME=Java
 BASE_REPO=openjdk
 VARIANTS=(browsers node node-browsers)
 
-TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
+TAG_FILTER="grep -v -e ^7 -e ^6 -e jre -e oraclelinux"
 
 function generate_customizations() {
 


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to an issue where we are pulling in oraclelinux images and wrongfully assuming apt is installed.