### PR TITLE
Persist the PHP_INI_DIR env var to avoid sudo -E

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -8,6 +8,8 @@ TAG_FILTER="grep -v -e rc -e beta"
 
 IMAGE_CUSTOMIZATIONS=$(cat <<'EOF'
 
+RUN echo 'Defaults    env_keep += "PHP_INI_DIR"' >> /etc/sudoers.d/env_keep
+
 # Install composer
 RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to this Discuss thread:

https://discuss.circleci.com/t/docker-php-ext-install-error-exited-with-123-directory-nonexistent/26786

There was a breaking change upstream in the PHP docker-php-ext-enable script that requires an environment variable only accessible to the main user. This change allows us to persist the required env var to the sudo shell without requiring the use of the -E on sudo.