### PR TITLE
remove hardcoded node version tag for android images

### DIFF
--- a/android/generate-images
+++ b/android/generate-images
@@ -21,7 +21,7 @@ for API in 23 24 25 26 27 28; do
   echo Generating Android ${API} Dockerfiles
 
   tag=api-${API}-alpha
-  node_variant_tag=api-${API}-node8-alpha
+  node_variant_tag=api-${API}-node-alpha
   ndk_variant_tag=api-${API}-ndk-r17b
 
   generate_dockerfile ${API} ${tag}


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to #286 

we were hardcoding `node8` into our node tags for android images; however, we recently bumped node to the current LTS version, which is 10

since we will likely continue bumping node in the future, & don't similarly hardcode a version # for `-node` variants of other images, we should likely not do so for android images

### Description
android images will simply have a `-node-alpha` tag, instead of `node8-alpha`