### PR TITLE
fix env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,9 +154,15 @@ jobs:
           command: |
             # rather than give internet scripts SU rights, we install to local user bin and add to path
 
-            export GOSS_DST=~/bin
+            # can't set these as normal job env vars, b/c they're overriden by the env section in the platform-specific jobs
+            export GOSS_DST="~/bin"
+            export GOSS_FILES_PATH="~/circleci-bundles/shared/images"
+            export GOSS_FILES_STRATEGY="cp"
+
             curl -fsSL https://goss.rocks/install | sh
             goss -version
+
+
 
       - run:
           name: Build, Test, Publish Images


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

trying to set goss env vars using circle's default config-based method; however, the `publish_image` job uses yaml anchors, & env vars set in the original version are overridden by a separate environment section in each image-building job

(fully adopting 2.1 functionality w/ parameterized jobs would probably fix this...)