### PR TITLE
Improve forked flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,15 @@ jobs:
             - "9c:e2:cf:bb:f2:25:4d:05:d9:b0:30:bf:73:c5:7d:8f"
 
       - run:
-          name: git config, git clone, git push
+          name: git config, git clone
+          command: |
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+            git config --global user.name "$CIRCLE_USERNAME"
+
+            git clone git@github.com:CircleCI-Public/example-images.git
+
+      - run:
+          name: git checkout, git push
           working_directory: example-images
           command: |
             # if this is a forked PR, stop this step;
@@ -92,11 +100,6 @@ jobs:
               circleci step halt
               echo "this is a forked PR; skipping push to example-images repo"
             fi
-
-            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-            git config --global user.name "$CIRCLE_USERNAME"
-
-            git clone git@github.com:CircleCI-Public/example-images.git
 
             git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
             cp -rfv /tmp/example-images/* ~/repo/example-images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,6 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "af:0a:93:75:51:75:1f:16:90:d9:97:b1:7a:bb:f0:27"
-      - run:
-          name: git config
-          command: |
-            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-            git config --global user.name "$CIRCLE_USERNAME"
-      - run: git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
 
       # push Dockerfiles to CircleCI-Public/circleci-dockerfiles on circleci-images pushes to all branches
       # checkout the equivalent branch on circleci-dockerfiiles
@@ -39,11 +33,26 @@ jobs:
       # eventually, some kind of cron job that prunes branches would be helpful, but populating that repo with tons of branches of dockerfiles isn't that annoying & will be helpful for development
 
       - run:
-          name: branch control flow & git push
+          name: git config, git clone, git push
           working_directory: circleci-dockerfiles
           command: |
+            # if this is a forked PR, stop this step;
+            # community contributors won't have perms to push to dockerfiles repo
+
+            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+              circleci step halt
+              echo "this is a forked PR; skipping push to circleci-dockeriles repo"
+            fi
+
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+            git config --global user.name "$CIRCLE_USERNAME"
+
+            git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
+
             git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
+
             cp -rfv /tmp/dockerfiles/* ~/repo/circleci-dockerfiles
+
             git add .
             git commit --allow-empty -m "Dockerfiles from $CIRCLE_BUILD_URL"
             git push -f origin $CIRCLE_BRANCH
@@ -55,29 +64,37 @@ jobs:
       - image: gcc:7
     steps:
       - checkout
+
       - run:
           name: Generate Dockerfiles, READMEs for automated builds
           command: |
             make -j
             make example_images
+
       - store_artifacts:
           path: /tmp/example-images
+
       - add_ssh_keys:
           fingerprints:
             - "9c:e2:cf:bb:f2:25:4d:05:d9:b0:30:bf:73:c5:7d:8f"
+
       - run:
-          name: git config
+          name: git config, git clone, git push
+          working_directory: example-images
           command: |
+            # if this is a forked PR, stop this step;
+            # community contributors won't have perms to push to example-images repo
+
+            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+              circleci step halt
+              echo "this is a forked PR; skipping push to example-images repo"
+            fi
+
             git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
             git config --global user.name "$CIRCLE_USERNAME"
 
-      - run: git clone git@github.com:CircleCI-Public/example-images.git
+            git clone git@github.com:CircleCI-Public/example-images.git
 
-      # push example Dockerfiles/READMEs to GitHub on circleci-images pushes to all branches
-      - run:
-          name: branch control flow & git push
-          working_directory: example-images
-          command: |
             git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
             cp -rfv /tmp/example-images/* ~/repo/example-images
             git add .
@@ -174,6 +191,16 @@ jobs:
 
             # setup test results for $PLATFORM
             mkdir test-results/$PLATFORM
+
+            # push images by default
+            export PUSH_IMAGES=true
+
+            # forked PR? set PUSH_IMAGES to false (build/test but don't push)
+            # community contributors won't have perms to push to our docker hub
+            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+              export PUSH_IMAGES=false
+              echo "forked PR: building/testing images; skipping `docker push`"
+            fi
 
             make -j -w -d $PLATFORM/publish_images
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,15 @@ jobs:
       # eventually, some kind of cron job that prunes branches would be helpful, but populating that repo with tons of branches of dockerfiles isn't that annoying & will be helpful for development
 
       - run:
-          name: git config, git clone, git push
+          name: git config, git clone
+          command: |
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+            git config --global user.name "$CIRCLE_USERNAME"
+
+            git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
+
+      - run:
+          name: git checkout, git push
           working_directory: circleci-dockerfiles
           command: |
             # if this is a forked PR, stop this step;
@@ -43,11 +51,6 @@ jobs:
               circleci step halt
               echo "this is a forked PR; skipping push to circleci-dockeriles repo"
             fi
-
-            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-            git config --global user.name "$CIRCLE_USERNAME"
-
-            git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
 
             git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
 

--- a/README.md
+++ b/README.md
@@ -137,15 +137,16 @@ A particular variant is pushed to Docker Hub only if tests pass; if not, the sam
 
 Tests run twice: once for `stdout`, and again, with JUnit formatting, for `store_test_results` (after some post-processing [due to how goss outputs JUnit XML](https://github.com/aelsabbahy/goss/blob/master/outputs/junit.go)...). With test runtimes at essentially zero seconds, running everything twice has a negligible effect on job runtime.
 
+By default, a given branch will push images to the [`ccitest` Docker Hub org](https://hub.docker.com/r/ccitest), with the branch name appended to all image tags. Once a given branch is merged to staging, staging will then push images to the [`ccistaging` Docker Hub org](https://hub.docker.com/r/ccistaging). Finally, we can rebuild those images on the [`circleci` Docker Hub org](https://hub.docker.com/r/circleci) by merging changes from `staging` into the `master` branch. See below for note on forked pull requests.
+
 #### Remaining work
 
 - Tests are very bare-bones right now and could use image-specific additions—please add things to each image's `goss.yml` file and the existing logic will take care of the rest!
 - The testing code is spread across the repository and is a bit confusing; some refactoring would help
 
 ## Limitations
-* The template language is WIP - it only supports `{{BASE_IMAGE}}` template.  We should extend this.
-* Generated Dockerfiles isn't checked into repo.  Since we track moving set of tags, checking into repository can create lots of unnecessary changes.
-* By default, a given branch will push images to the [`ccitest` Docker Hub org](https://hub.docker.com/r/ccitest), with the branch name appended to all image tags. Once a given branch is merged to staging, staging will then push images to the [`ccistaging` Docker Hub org](https://hub.docker.com/r/ccistaging). Finally, we can rebuild those images on the [`circleci` Docker Hub org](https://hub.docker.com/r/circleci) by merging changes from `staging` into the `master` branch.
+* We welcome and appreciate contributions (issues, PRs) from the community! However, for security reasons, forked pull requests will not push Dockerfiles to [CircleCI-Public/circleci-dockerfiles](https://github.com/CircleCI-Public/circleci-dockerfiles), example images to [CircleCI-Public/example-images](https://github.com/CircleCI-Public/example-images), or images to Docker Hub. All Dockerfiles, example image Dockerfiles/READMEs, and images will generate/build in forked PR jobs as expected; however, nothing will be pushed to external CircleCI resources.
+* The template language is a WIP—it only supports `{{BASE_IMAGE}}` template. We should extend this.
 * We cannot support Oracle JDK for licensing reasons. See [Oracle's Binary Code License Agreement for the Java SE Platform](http://oracle.com/technetwork/java/javase/terms/license/index.html) and [Stack Exchange: Is there no Oracle JDK for docker?](https://devops.stackexchange.com/questions/433/is-there-no-oracle-jdk-for-docker) for details.
 
 ## Licensing

--- a/shared/images/build.sh
+++ b/shared/images/build.sh
@@ -135,14 +135,22 @@ then
 
     run_goss_tests
 
-    docker push $IMAGE_NAME
+    # provide an option to build but not push images
+    # this can be used to build/test images on forked PRs
+    # or just to skip pushing if desired
 
-    handle_ccitest_org_images
+    if [[ $PUSH_IMAGES == true ]]; then
+        docker push $IMAGE_NAME
 
-    update_aliases
+        handle_ccitest_org_images
+
+        update_aliases
+    fi
 
     # variants don't get reused, clean them up
     docker image rm $IMAGE_NAME
+
+    popd
 else
     # when building the new base image - always try to pull from latest
     # also keep new base images around for variants
@@ -150,11 +158,17 @@ else
 
     run_goss_tests
 
-    docker push $IMAGE_NAME
+    # provide an option to build but not push images
+    # this can be used to build/test images on forked PRs
+    # or just to skip pushing if desired
 
-    handle_ccitest_org_images
+    if [[ $PUSH_IMAGES == true ]]; then
+        docker push $IMAGE_NAME
 
-    update_aliases
+        handle_ccitest_org_images
+
+        update_aliases
+    fi
+
+    popd
 fi
-
-popd


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context
sometimes we get PRs from community members, like https://github.com/circleci/circleci-images/pull/304, which is awesome!

but the way the repo is currently configured, most of our jobs fail for forked PRs b/c they depend on being able to hit external circleci resources, & we don't give forked PRs access to the requisite creds (for good reason!).

this PR makes some changes to our build/push infrastructure to skip certain steps in certain jobs/scripts if a particular workflow is running from a forked PR. this way, contributors from the community can see images build and test in their CircleCI jobs.

### Description
control flow in `build.sh` & `config.yml` to check for forked PR status, & if so, skip anything that would fail, while running everything else normally
