### PR TITLE
add same logic to refresh-tools-cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,17 +49,17 @@ jobs:
 
             if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
               echo "this is a forked PR; skipping push to circleci-dockeriles repo"
-              # circleci step halt
-              # ^^ this seems broken right now
-            else
-              git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
-
-              cp -rfv /tmp/dockerfiles/* ~/repo/circleci-dockerfiles
-
-              git add .
-              git commit --allow-empty -m "Dockerfiles from $CIRCLE_BUILD_URL"
-              git push -f origin $CIRCLE_BRANCH
+              circleci step halt
+              exit 0
             fi
+
+            git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
+
+            cp -rfv /tmp/dockerfiles/* ~/repo/circleci-dockerfiles
+
+            git add .
+            git commit --allow-empty -m "Dockerfiles from $CIRCLE_BUILD_URL"
+            git push -f origin $CIRCLE_BRANCH
 
   generate_automated_build_images:
     working_directory: ~/repo
@@ -99,27 +99,27 @@ jobs:
 
             if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
               echo "this is a forked PR; skipping push to example-images repo"
-              # circleci step halt
-              # ^^ this seems broken right now
+              circleci step halt
+              exit 0
+            fi
+
+            git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
+
+            cp -rfv /tmp/example-images/* ~/repo/example-images
+
+            git add .
+            git commit --allow-empty -m "example images from $CIRCLE_BUILD_URL"
+
+            if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "staging" ]]; then
+              git push -f origin $CIRCLE_BRANCH
             else
-              git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
+              # docker hub automated builds on the ccitest org are looking for tags of the following pattern:
+              # /ccitest-*/
+              # append the branch (since that org pulls from all non-master/staging branches) & SHA1
 
-              cp -rfv /tmp/example-images/* ~/repo/example-images
-
-              git add .
-              git commit --allow-empty -m "example images from $CIRCLE_BUILD_URL"
-
-              if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "staging" ]]; then
-                git push -f origin $CIRCLE_BRANCH
-              else
-                # docker hub automated builds on the ccitest org are looking for tags of the following pattern:
-                # /ccitest-*/
-                # append the branch (since that org pulls from all non-master/staging branches) & SHA1
-
-                CCITEST_TAG=ccitest-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}
-                git tag $CCITEST_TAG
-                git push origin $CCITEST_TAG
-              fi
+              CCITEST_TAG=ccitest-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}
+              git tag $CCITEST_TAG
+              git push origin $CCITEST_TAG
             fi
 
   refresh_tools_cache:
@@ -129,7 +129,17 @@ jobs:
     steps:
       - checkout
       - run: sudo pip install awscli==1.14.17
-      - run: cd ./shared/images; ./refresh-tools-cache
+      - run: |
+          # if this is a forked PR, stop this step;
+          # community contributors won't have perms to upload to our S3 bucket
+
+          if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+            echo "this is a forked PR; skipping rest of this step"
+            circleci step halt
+            exit 0
+          fi
+
+          cd ./shared/images; ./refresh-tools-cache
 
   publish_image: &publish_image
     machine: true


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

`refresh-tools-cache` hits our S3 bucket—open-source contributors won't have perms to do this

add same forked PR logic to this job