### PR TITLE
Fix forked prs 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
       # skip pushing identical dockerfiles to circleci-dockerfiles if relevant code is unchanged
       - run:
-          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
+          name: only proceed if `shared` or `Makefile` or any image dirs were modified (unless we're on master)
           command: |
             # save value stored in file to a local env var
             CIRCLE_COMPARE_URL=$(cat workspace/CIRCLE_COMPARE_URL.txt)
@@ -44,7 +44,8 @@ jobs:
             if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
               echo "this is a forked PR; skipping push to circleci-dockerfiles repo"
             else
-              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
+              make list_bundles
+              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "shared" -e "Makefile" -f BUNDLES.txt) && "$CIRCLE_BRANCH" != "master" ]]; then
                 circleci step halt
                 exit 0
               fi
@@ -103,7 +104,7 @@ jobs:
       # skip pushing identical Dockerfiles/READMEs to example-images if relevant code is unchanged
       # will also avoid tons of unecessary queueing in our Docker Hub automated builds
       - run:
-          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
+          name: only proceed if `shared` or `Makefile` or any image dirs were modified (unless we're on master)
           command: |
             # save value stored in file to a local env var
             CIRCLE_COMPARE_URL=$(cat workspace/CIRCLE_COMPARE_URL.txt)
@@ -119,7 +120,8 @@ jobs:
             if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
               echo "this is a forked PR; skipping push to example-images repo"
             else
-              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
+              make list_bundles
+              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "shared" -e "Makefile" -f BUNDLES.txt) && "$CIRCLE_BRANCH" != "master" ]]; then
                 circleci step halt
                 exit 0
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ commit_workflow_filters: &commit_workflow_filters
   scheduled-workflow: false
   requires:
     - refresh_tools_cache
-    - circle-compare-url/reconstruct
+    - reconstruct_compare_url
 
 workflows:
   version: 2
@@ -399,6 +399,7 @@ workflows:
           requires:
             - generate_automated_build_images
       - circle-compare-url/reconstruct:
+          name: reconstruct_compare_url
           resource-class: small
           requires:
             - generate_automated_build_images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,6 @@ jobs:
       - run:
           name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
           command: |
-            set -u
-
             # save value stored in file to a local env var
             CIRCLE_COMPARE_URL=$(cat workspace/CIRCLE_COMPARE_URL.txt)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,40 @@ jobs:
       - store_artifacts:
           path: /tmp/dockerfiles
           destination: Dockerfiles
-      # upload Dockerfiles to circleci-public/circleci-dockerfiles repo
+
+      - attach_workspace:
+          at: workspace
+
+      # skip pushing identical dockerfiles to circleci-dockerfiles if relevant code is unchanged
+      - run:
+          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
+          command: |
+            # save value stored in file to a local env var
+            CIRCLE_COMPARE_URL=$(cat workspace/CIRCLE_COMPARE_URL.txt)
+
+            # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
+
+            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+            echo "Commit range: $COMMIT_RANGE"
+
+            # if this is a forked PR, skip commit range logic; it doesn't handle forks well
+            # community contributors won't have perms to push to dockerfiles repo anyway
+
+            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+              echo "this is a forked PR; skipping push to circleci-dockerfiles repo"
+            else
+              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
+                circleci step halt
+                exit 0
+              fi
+            fi
+
+      # otherwise, upload Dockerfiles to circleci-public/circleci-dockerfiles repo
       - add_ssh_keys:
           fingerprints:
             - "af:0a:93:75:51:75:1f:16:90:d9:97:b1:7a:bb:f0:27"
 
-      # push Dockerfiles to CircleCI-Public/circleci-dockerfiles on circleci-images pushes to all branches
+      # potentailly push Dockerfiles to CircleCI-Public/circleci-dockerfiles on circleci-images pushes to any branch
       # checkout the equivalent branch on circleci-dockerfiiles
       # if it doesn't exist, create it
       # eventually, some kind of cron job that prunes branches would be helpful, but populating that repo with tons of branches of dockerfiles isn't that annoying & will be helpful for development
@@ -44,15 +72,6 @@ jobs:
           name: git checkout, git push
           working_directory: circleci-dockerfiles
           command: |
-            # if this is a forked PR, stop this step;
-            # community contributors won't have perms to push to dockerfiles repo
-
-            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
-              echo "this is a forked PR; skipping push to circleci-dockeriles repo"
-              circleci step halt
-              exit 0
-            fi
-
             git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
 
             cp -rfv /tmp/dockerfiles/* ~/repo/circleci-dockerfiles
@@ -78,6 +97,34 @@ jobs:
       - store_artifacts:
           path: /tmp/example-images
 
+      - attach_workspace:
+          at: workspace
+
+      # skip pushing identical Dockerfiles/READMEs to example-images if relevant code is unchanged
+      # will also avoid tons of unecessary queueing in our Docker Hub automated builds
+      - run:
+          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
+          command: |
+            # save value stored in file to a local env var
+            CIRCLE_COMPARE_URL=$(cat workspace/CIRCLE_COMPARE_URL.txt)
+
+            # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
+
+            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+            echo "Commit range: $COMMIT_RANGE"
+
+            # if this is a forked PR, skip commit range logic; it doesn't handle forks well
+            # community contributors won't have perms to push to example-images repo anyway
+
+            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+              echo "this is a forked PR; skipping push to example-images repo"
+            else
+              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
+                circleci step halt
+                exit 0
+              fi
+            fi
+
       - add_ssh_keys:
           fingerprints:
             - "9c:e2:cf:bb:f2:25:4d:05:d9:b0:30:bf:73:c5:7d:8f"
@@ -94,15 +141,6 @@ jobs:
           name: git checkout, git push
           working_directory: example-images
           command: |
-            # if this is a forked PR, stop this step;
-            # community contributors won't have perms to push to example-images repo
-
-            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
-              echo "this is a forked PR; skipping push to example-images repo"
-              circleci step halt
-              exit 0
-            fi
-
             git checkout $(git show-ref --verify --quiet refs/heads/$CIRCLE_BRANCH || echo '-b') $CIRCLE_BRANCH
 
             cp -rfv /tmp/example-images/* ~/repo/example-images
@@ -125,7 +163,7 @@ jobs:
   refresh_tools_cache:
     resource_class: small
     docker:
-      - image: circleci/python:3.6.6 # aws cli dependenncy pyaml does not yet support 3.7 - https://github.com/aws/aws-cli/issues/3427
+      - image: circleci/python:3.6.6 # aws cli dependency pyaml does not yet support 3.7 - https://github.com/aws/aws-cli/issues/3427
     steps:
       - checkout
       - run: sudo pip install awscli==1.14.17
@@ -353,7 +391,6 @@ commit_workflow_filters: &commit_workflow_filters
   scheduled-workflow: false
   requires:
     - refresh_tools_cache
-    - reconstruct_compare_url
 
 workflows:
   version: 2
@@ -391,15 +428,16 @@ workflows:
 
   commit:
     jobs:
-      - generate_dockerfiles
-      - generate_automated_build_images
-      - refresh_tools_cache:
-          requires:
-            - generate_dockerfiles
-            - generate_automated_build_images
       - circle-compare-url/reconstruct:
           name: reconstruct_compare_url
           resource-class: small
+      - generate_dockerfiles:
+          requires:
+            - reconstruct_compare_url
+      - generate_automated_build_images:
+          requires:
+            - reconstruct_compare_url
+      - refresh_tools_cache:
           requires:
             - generate_dockerfiles
             - generate_automated_build_images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  circle-compare-url: iynere/compare-url@dev:refactor-add-job-4477a0b7c744362ef6f51d9e6e566e067ebcb58c
+  circle-compare-url: iynere/compare-url@0.3.1
 
 jobs:
   generate_dockerfiles:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  circle-compare-url: iynere/compare-url@dev:refactor-add-job-ebdd88320adc203366cdb654db0ebd21741f578a
+  circle-compare-url: iynere/compare-url@dev:refactor-add-job-4477a0b7c744362ef6f51d9e6e566e067ebcb58c
 
 jobs:
   generate_dockerfiles:
@@ -179,8 +179,18 @@ jobs:
             COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
             echo "Commit range: $COMMIT_RANGE"
 
-            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
-              circleci step halt
+            # if this is a forked PR, skip commit range logic;
+            # it doesn't handle forks well, plus we likely want to
+            # always build all images on forks anyway, to help
+            # community members assess their PRs and ultimately be
+            # able to make meaningful contributions to the repo
+
+            if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
+              echo "this is a forked PR; building/testing all images"
+            else
+              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
+                circleci step halt
+              fi
             fi
 
       - run:
@@ -392,6 +402,7 @@ workflows:
           requires:
             - generate_automated_build_images
       - circle-compare-url/reconstruct:
+          resource-class: small
           requires:
             - generate_automated_build_images
       - publish_android:        *commit_workflow_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,11 +177,10 @@ jobs:
             COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
             echo "Commit range: $COMMIT_RANGE"
 
-            # if this is a forked PR, skip commit range logic;
-            # it doesn't handle forks well, plus we likely want to
-            # always build all images on forks anyway, to help
-            # community members assess their PRs and ultimately be
-            # able to make meaningful contributions to the repo
+            # if this is a forked PR, skip commit range logic; it doesn't handle forks well,
+            # plus we likely want to always build all images on forks anyway,
+            # to help community members assess their PRs and ultimately
+            # be able to make meaningful contributions to the repo
 
             if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
               echo "this is a forked PR; building/testing all images"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,16 +392,16 @@ workflows:
   commit:
     jobs:
       - generate_dockerfiles
-      - generate_automated_build_images:
-          requires:
-            - generate_dockerfiles
+      - generate_automated_build_images
       - refresh_tools_cache:
           requires:
+            - generate_dockerfiles
             - generate_automated_build_images
       - circle-compare-url/reconstruct:
           name: reconstruct_compare_url
           resource-class: small
           requires:
+            - generate_dockerfiles
             - generate_automated_build_images
       - publish_android:        *commit_workflow_filters
       - publish_node:           *commit_workflow_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  circle-compare-url: iynere/compare-url@0.1.5
+  circle-compare-url: iynere/compare-url@dev:refactor-add-job-ebdd88320adc203366cdb654db0ebd21741f578a
 
 jobs:
   generate_dockerfiles:
@@ -163,28 +163,25 @@ jobs:
               docker login -u $DOCKER_USER -p $DOCKER_PASS
             fi
 
-      - unless:
-          condition: <<parameters.scheduled-workflow>>
-          steps:
-            - circle-compare-url/reconstruct:
-                project-path: ~/circleci-bundles
+      - attach_workspace:
+          at: workspace
 
-            - run:
-                name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
-                command: |
-                  set -u
+      - run:
+          name: only proceed if `$PLATFORM` or `shared` or `Makefile` were modified (unless we're on master)
+          command: |
+            set -u
 
-                  # save value stored in file to a local env var
-                  CIRCLE_COMPARE_URL=$(cat CIRCLE_COMPARE_URL.txt)
+            # save value stored in file to a local env var
+            CIRCLE_COMPARE_URL=$(cat workspace/CIRCLE_COMPARE_URL.txt)
 
-                  # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
+            # borrowed from https://discuss.circleci.com/t/does-circleci-2-0-work-with-monorepos
 
-                  COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
-                  echo "Commit range: $COMMIT_RANGE"
+            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+            echo "Commit range: $COMMIT_RANGE"
 
-                  if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
-                    circleci step halt
-                  fi
+            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "$PLATFORM" -e "shared" -e "Makefile") && "$CIRCLE_BRANCH" != "master" ]]; then
+              circleci step halt
+            fi
 
       - run:
           name: Install goss & dgoss (orbify this later)
@@ -349,6 +346,7 @@ commit_workflow_filters: &commit_workflow_filters
   scheduled-workflow: false
   requires:
     - refresh_tools_cache
+    - circle-compare-url/reconstruct
 
 workflows:
   version: 2
@@ -391,6 +389,9 @@ workflows:
           requires:
             - generate_dockerfiles
       - refresh_tools_cache:
+          requires:
+            - generate_automated_build_images
+      - circle-compare-url/reconstruct:
           requires:
             - generate_automated_build_images
       - publish_android:        *commit_workflow_filters

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 /*/images/
 *.DS_Store
 BUNDLES.txt
+
+android/resources/
+clojure/resources/
+elixir/resources/
+golang/resources/
+jruby/resources/
+openjdk/resources/
+php/resources/
+python/resources/
+ruby/resources/
+rust/resources/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*/images/
 *.DS_Store
+BUNDLES.txt

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ BUNDLES = \
   postgres mariadb mysql mongo dynamodb elixir \
   jruby clojure openjdk buildpack-deps redis rust
 
+list_bundles: $(foreach b, $(BUNDLES), $(b)/echo_bundle)
+
+%/echo_bundle:
+	echo $(@D) >> BUNDLES.txt
+
 images: $(foreach b, $(BUNDLES), $(b)/generate_images)
 
 %/generate_images:

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,6 @@ BUNDLES = \
   postgres mariadb mysql mongo dynamodb elixir \
   jruby clojure openjdk buildpack-deps redis rust
 
-list_bundles: $(foreach b, $(BUNDLES), $(b)/echo_bundle)
-
-%/echo_bundle:
-	echo $(@D) >> BUNDLES.txt
-
 images: $(foreach b, $(BUNDLES), $(b)/generate_images)
 
 %/generate_images:
@@ -31,3 +26,8 @@ clean: $(foreach b, $(BUNDLES), $(b)/clean)
 
 %/clean:
 	cd $(@D) ; rm -r images || true
+
+list_bundles: $(foreach b, $(BUNDLES), $(b)/echo_bundle)
+
+%/echo_bundle:
+	echo $(@D) >> BUNDLES.txt

--- a/postgres/generate-images
+++ b/postgres/generate-images
@@ -18,9 +18,9 @@ function generate_postgis_ram_variant() {
 mkdir -p resources
 generate_postgis_ram_variant > resources/Dockerfile-postgis-ram.template
 
-# Temporarily removed the PostGIS variant images for PostgreSQL 11 (PG11). 
-# PostGIS v2.4.4 is failing to compile with PG11 causing the apt package 
-# potgresql-11-postgis-2.4 to not be available, failing builds. The v2.5.0 
-# release of PostGIS will fix this, which will also cause a new apt package 
+# Temporarily removed the PostGIS variant images for PostgreSQL 11 (PG11).
+# PostGIS v2.4.4 is failing to compile with PG11 causing the apt package
+# potgresql-11-postgis-2.4 to not be available, failing builds. The v2.5.0
+# release of PostGIS will fix this, which will also cause a new apt package
 # name. We'll need to tackle that issue once PostgreSQL 11 is released.
 rm -r ./images/11*/postgis{,-ram}/


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

## Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

## Motivation and Context

some final changes to ensure that community-submitted PRs (like https://github.com/circleci/circleci-images/pull/306) can build & test as expected

also use the updated compare-url orb, which has a job instead of a command, so it only needs to run once, in one container, to have results used by all image-publishing jobs

## Other changes

as usual, this PR ballooned out of control as i kept seeing additional opportunities to improve things / fix bugs:

- the Workflows job order has been restructured: compare-url orb job runs first, then we run dockerfiles & automated builds simultaneously, then refresh tool cache, then all image jobs. we can use the results of the compare url orb to decide whether or not to proceed w/ pushing to circleci-dockerfiles or example-images (no need to clutter them up with identical files if no relevant code has changed)
- as part of that, there's a new Make target to take the list of bundles at the top of the Makefile & echo it into a fiile, for use in pattern-matching
- also formally gitignored a bunch of `$IMAGE/resources` directories that are generated by `make -j`, but not removed by `make clean`, & not necessary for image-building (ie, don't need to be checked in)—confusingly, some images _do_ need their resources directories checked in, while others don't