### PR TITLE
add Erlang images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUNDLES = \
   android node python ruby golang php \
-  postgres mariadb mysql mongo dynamodb elixir \
+  postgres mariadb mysql mongo dynamodb elixir erlang \
   jruby clojure openjdk buildpack-deps redis rust
 
 images: $(foreach b, $(BUNDLES), $(b)/generate_images)

--- a/erlang/generate-images
+++ b/erlang/generate-images
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+NAME="erlang"
+BASE_REPO=erlang
+VARIANTS=()
+
+# set to true when alpine images don't end up with debian commands
+INCLUDE_ALPINE=false
+
+# boilerplate
+source ../shared/images/generate.sh

--- a/erlang/goss.yaml
+++ b/erlang/goss.yaml
@@ -1,0 +1,13 @@
+file:
+  # ensure a basic shell exists
+  /bin/sh:
+    exists: true
+
+  # ensure basic directory structure created
+  /home/circleci:
+    exists: true
+
+user:
+  # ensure circleci user exists
+  circleci:
+    exists: true


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

Official Erlang images lack certain packages necessary for all features of CircleCI to work. I was hoping this could be included in the CircleCI set of images and then I can use those for the rebar3 orb, https://circleci.com/orbs/registry/orb/tsloughter/rebar3 -- I might get this moved to an Erlang namespace eventually since we have rebar3 under the Erlang organization on github.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

Adds images for Erlang. I'd like alpine to be included but right now it looks like there isn't a way to get the generated images to use `apk` instead of `apt` in install commands that are added to the Dockerfile.