### PR TITLE
run compare-url job on cron workflow, too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
 
   publish_android:
     <<: *publish_image
-    parallelism: 20
+    parallelism: 25
     environment:
       - PLATFORM: android
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
             # community contributors won't have perms to push to our docker hub
             if [[ $CIRCLE_PR_REPONAME == "circleci-images" ]]; then
               export PUSH_IMAGES=false
-              echo "forked PR: building/testing images; skipping `docker push`"
+              echo "forked PR: building/testing images; skipping docker push"
             fi
 
             make -j $PLATFORM/publish_images # add -w -d for debug info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,12 @@ workflows:
               only:
                 - master
     jobs:
-      - generate_dockerfiles
+      - circle-compare-url/reconstruct:
+          name: reconstruct_compare_url
+          resource-class: small
+      - generate_dockerfiles:
+          requires:
+            - reconstruct_compare_url
       - refresh_tools_cache:
           requires:
             - generate_dockerfiles


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

image-building jobs currently depend on `CIRCLE_COMPARE_URL` having been reconstructed, so without this change, our daily `cron` workflow on `master` will fail, as the env var won't exist

we always build all images on master anyway, so we don't technically _need_ to reconstruct `CIRCLE_COMPARE_URL`, but this is the simplest fix & the job only takes a few seconds, so i think it's fine for now