### PR TITLE
Fixing Android Platform 28 SDK license not accepted

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -75,7 +75,7 @@ ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bi
 
 RUN mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
 
-RUN yes | sdkmanager --licenses && sdkmanager --update
+RUN yes | sdkmanager --licenses && yes | sdkmanager --update
 
 # Update SDK manager and install system image, platform and build tools
 RUN sdkmanager \


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to the issue raised in discuss.circleci.com [Android Platform 28 SDK license not accepted](https://discuss.circleci.com/t/android-platform-28-sdk-license-not-accepted/27768).

Builds relying on Android images are failing as not all the Android SDK licenses are accepted.

```
Failed to install the following Android SDK packages as some licences have not been accepted.
           build-tools;28.0.2 Android SDK Build-Tools 28.0.2
        To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
        Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
```
This is because the default operations in the [circleci docker image](https://github.com/circleci/circleci-images/blob/f8d3245ff0af13e54f7fb14c5abbdb3d44ee0f6c/android/Dockerfile.m4#L78) fail to accept the Android SDK license.

```
#!/bin/bash
yes | sdkmanager --licenses && sdkmanager --update
Picked up _JAVA_OPTIONS: -Xmx15375m -XX:ParallelGCThreads=8 -XX:ConcGCThreads=8 -Djava.util.concurrent.ForkJoinPool.common.parallelism=8 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
All SDK package licenses accepted.

Picked up _JAVA_OPTIONS: -Xmx15375m -XX:ParallelGCThreads=8 -XX:ConcGCThreads=8 -Djava.util.concurrent.ForkJoinPool.common.parallelism=8 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
License android-sdk-license:
---------------------------------------
Terms and Conditions

This is the Android Software Development Kit License Agreement
...

January 16, 2019
---------------------------------------
Accept? (y/N): Skipping following packages as the license is not accepted:
Android Emulator
The following packages can not be installed since their licenses or those of the packages they depend on were not accepted:
  emulator
[=======================================] 100% Computing updates...   
```

### Description

Modified the original command (#88) to accept all the requested licences.
