### PR TITLE
Adding Android Build Tools 28.0.1 and 28.0.2

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -95,6 +95,8 @@ RUN sdkmanager \
   "build-tools;27.0.2" \
   "build-tools;27.0.3" \
   "build-tools;28.0.0" \
+  "build-tools;28.0.1" \
+  "build-tools;28.0.2" \
   "build-tools;28.0.3"
 
 # API_LEVEL string gets replaced by m4


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to license agreements not accepted when Android compile version is set to 27. Attempts to use Build Tools 28.0.2.

This is an extension to https://github.com/circleci/circleci-images/pull/318

### Description

Adding in missing Build Tools versions from 28
