### PR TITLE
Dont filter Docker releases using old '-ce' suffix

### DIFF
--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -42,7 +42,7 @@ RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linu
 #>    /usr/local/bin/dockerd
 
 RUN set -ex \
-  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
   && echo Docker URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to #324 .

<!--- Why is this change required? What problem does it solve? -->
This change removes the filter from the Docker download script. Without this change, no stable versions of Docker newer than 18.06.1 will ever be installed in a CircleCI image.
<!--- Please describe in detail how you tested your changes. --->

I tested this change by first shelling into an existing image and running the modified line to update docker, then adding it to my own CircleCI config.yml as a build step. This change works in both cases.

### Description
<!--- Describe your changes in detail -->
I have simply removed the '-ce' from the grep filter that filters through the stable releases of Docker.
