### PR TITLE
android: Update Ruby to v2.6.1

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -55,10 +55,10 @@ RUN cd /tmp && wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/r
     tar -xzvf ruby-install-0.6.1.tar.gz && \
     cd ruby-install-0.6.1 && \
     sudo make install && \
-    ruby-install --cleanup ruby 2.4.3 && \
+    ruby-install --cleanup ruby 2.6.1 && \
     rm -r /tmp/ruby-install-*
 
-ENV PATH ${HOME}/.rubies/ruby-2.4.3/bin:${PATH}
+ENV PATH ${HOME}/.rubies/ruby-2.6.1/bin:${PATH}
 RUN echo 'gem: --env-shebang --no-rdoc --no-ri' >> ~/.gemrc && gem install bundler
 
 # Download and install Android SDK


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary. (Don't think it was necessary.)

### Motivation and Context

This PR doesn't have a corresponding issue, and is just a followup to my previous PR (#314) which I had to close because I deleted my fork prematurely.

This new version of Ruby was released at the end of January, and includes a large number of speed gains and new low-level features I'd like to be able to use, as I imagine many others would.

I would understand if this is too much of a jump, but since 2.6.1 is semver-backwards-compatible with 2.4.3, I would think it shouldn't be too scary.

I have tested this locally with a full `fastlane` suite on a React-Native codebase. Fastlane is a common Ruby-based build script in Android, and it worked fine. `make` exits successfully.

### Description

`s/2\.4\.3/2\.6\.1/g` in `Dockerfile.mk`. See diff. (It's a two-line substitution.)

See also #314.

CC @felicianotech and @iynere, commenters on my previous PR.