### PR TITLE
Jkg/latest release chromedriver fix

### DIFF
--- a/shared/images/Dockerfile-browsers-legacy.template
+++ b/shared/images/Dockerfile-browsers-legacy.template
@@ -60,8 +60,9 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
            "/opt/google/chrome/google-chrome" \
       && google-chrome --version
 
-RUN export CHROMEDRIVER_RELEASE=$(2.45) \
-      # && $(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+# move this back below `RUN` after google fixes chromedriver 2.46 beta issue
+# && $(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROMEDRIVER_RELEASE=2.45 \
       && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
       && cd /tmp \
       && unzip chromedriver_linux64.zip \

--- a/shared/images/Dockerfile-browsers-legacy.template
+++ b/shared/images/Dockerfile-browsers-legacy.template
@@ -53,6 +53,8 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
 
 # install chrome
 
+ENV LATEST_RELEASE 2.45
+
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
@@ -60,7 +62,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
            "/opt/google/chrome/google-chrome" \
       && google-chrome --version
 
-RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/${LATEST_RELEASE}) \
       && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
       && cd /tmp \
       && unzip chromedriver_linux64.zip \

--- a/shared/images/Dockerfile-browsers-legacy.template
+++ b/shared/images/Dockerfile-browsers-legacy.template
@@ -53,8 +53,6 @@ RUN FIREFOX_URL="https://s3.amazonaws.com/circle-downloads/firefox-mozilla-build
 
 # install chrome
 
-ENV LATEST_RELEASE 2.45
-
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
@@ -62,7 +60,8 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
            "/opt/google/chrome/google-chrome" \
       && google-chrome --version
 
-RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/${LATEST_RELEASE}) \
+RUN export CHROMEDRIVER_RELEASE=$(2.45) \
+      # && $(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
       && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
       && cd /tmp \
       && unzip chromedriver_linux64.zip \

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -40,8 +40,6 @@ RUN export GECKODRIVER_LATEST_RELEASE_URL=$(curl https://api.github.com/repos/mo
 
 # install chrome
 
-ENV LATEST_RELEASE 2.45
-
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
@@ -49,7 +47,8 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
            "/opt/google/chrome/google-chrome" \
       && google-chrome --version
 
-RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/${LATEST_RELEASE}) \
+RUN export CHROMEDRIVER_RELEASE=$(2.45)
+      # && $(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
       && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
       && cd /tmp \
       && unzip chromedriver_linux64.zip \

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -40,6 +40,8 @@ RUN export GECKODRIVER_LATEST_RELEASE_URL=$(curl https://api.github.com/repos/mo
 
 # install chrome
 
+ENV LATEST_RELEASE 2.45
+
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
       && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
       && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
@@ -47,7 +49,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
            "/opt/google/chrome/google-chrome" \
       && google-chrome --version
 
-RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN export CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/${LATEST_RELEASE}) \
       && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
       && cd /tmp \
       && unzip chromedriver_linux64.zip \

--- a/shared/images/Dockerfile-browsers.template
+++ b/shared/images/Dockerfile-browsers.template
@@ -47,8 +47,9 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
            "/opt/google/chrome/google-chrome" \
       && google-chrome --version
 
-RUN export CHROMEDRIVER_RELEASE=$(2.45)
-      # && $(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+# move this back below `RUN` after google fixes chromedriver 2.46 beta issue
+# && $(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROMEDRIVER_RELEASE=2.45 \
       && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
       && cd /tmp \
       && unzip chromedriver_linux64.zip \


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [?] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to problem ticket "Google released a beta of chromedriver rather than a full release which has broken many projects" https://circleci.zendesk.com/agent/tickets/47945.

<!--- Why is this change required? What problem does it solve? -->
pins stable version vs beta (beta is the current state  of LATEST_RELEASE on this url that broke images)
http://chromedriver.storage.googleapis.com/LATEST_RELEASE
is 2.46
stable is 2.45

<!--- Please describe in detail how you tested your changes. --->
Have not tested yet - circleci.com not picking up my commit yet as we are having an outage

### Description
<!--- Describe your changes in detail -->
