### PR TITLE
Update Android NDK to r19c

### DIFF
--- a/android/Dockerfile-ndk.template
+++ b/android/Dockerfile-ndk.template
@@ -1,9 +1,11 @@
 
-ARG ndk_version=android-ndk-r17b
+ARG ndk_version=android-ndk-r18c
+ARG ndk_sha256=4c62514ec9c2309315fd84da6d52465651cdb68605058f231f1e480fcf2692e1
 ARG android_ndk_home=/opt/android/${ndk_version}
 
 # install NDK
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/${ndk_version}.zip https://dl.google.com/android/repository/${ndk_version}-linux-x86_64.zip && \
+    echo "${ndk_sha256}  ${ndk_version}-linux-x86_64.zip" > ${ndk_version}-linux-x86_64.zip.sha256 && sha256sum -c ${ndk_version}-linux-x86_64.zip.sha256 && 
     sudo unzip -q /tmp/${ndk_version}.zip -d /opt/android && \
     rm /tmp/${ndk_version}.zip && \
     sudo chown -R circleci:circleci ${android_ndk_home}


### PR DESCRIPTION
- Use r19c, released Jan 2019
- Was on old version r17b from mid 2018
- https://developer.android.com/ndk/downloads/revision_history

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x ] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x ] I've updated the documentation if necessary. (Not needed, no references to NDK version found)

### Motivation and Context

This PR relates to keeping the Android build toolchain up-to-date with official releases from Google.

Rather than forcing developers to download the latest NDK on their own, use a pre-baked version of the latest NDK.

### Description
- Use new NDK version
- Check SHA-256 hash of downloaded NDK for additional security
