### PR TITLE
Lower parallelism for PHP job so it doesn't fail.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
 
   publish_php:
     <<: *publish_image
-    parallelism: 20
+    parallelism: 16
     environment:
       - PLATFORM: php
 


### PR DESCRIPTION
Fix the PHP job.

The parallelism number of 20 is no longer working for us. There wasn't a tag to build in some of the containers. Dropping it to 18 didn't seem to work so I settled on 16, which has consistently passed builds.