### PR TITLE
Fix OpenJDK Builds

### DIFF
--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -4,7 +4,8 @@ NAME=Java
 BASE_REPO=openjdk
 VARIANTS=(browsers node node-browsers)
 
-TAG_FILTER="grep -v -e ^7 -e ^6 -e jre -e oraclelinux"
+TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
+TAG_INCLUDE_FILTER="grep stretch"
 
 function generate_customizations() {
 

--- a/shared/images/generate.sh
+++ b/shared/images/generate.sh
@@ -12,6 +12,7 @@ NEW_REPO=${NEW_REPO:-${NEW_ORG}/${BASE_REPO_BASE}}
 INCLUDE_ALPINE=${INCLUDE_ALPINE:-false}
 
 TAG_FILTER="${TAG_FILTER:-cat}"
+TAG_INCLUDE_FILTER="${TAG_INCLUDE_FILTER:-cat}"
 
 CIRCLE_NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
@@ -28,6 +29,7 @@ function find_tags_and_aliases() {
     | sed  's/^.*Tags: //g' \
     | grep -v $ALPINE_TAG -e 'slim' -e 'onbuild' -e windows -e wheezy -e nanoserver \
     | ${TAG_FILTER} \
+    | ${TAG_INCLUDE_FILTER} \
     | sed 's/, /:/' \
     | sed 's/, /,/g' \
     | sort | awk "NR % ${CIRCLE_NODE_TOTAL} == ${CIRCLE_NODE_INDEX}"


### PR DESCRIPTION
This PR fixes the OpenJDK job by being more specific with which Docker tags we use.

The OpenJDK Docker Team changed their base OS variants. With v11, they introduced more Oracle/Oracle Linux variants. Those images aren't Debian-based and thus don't have `apt-get`. Our build script installs tools such as Apache Ant via Apt-Get thus is failing.

With v12, Oracle Linux has become their default base distro, resulting in even more tags that we can't build.

From what I've seen, there's bases of Oracle Linux, Windows Core, Alpine, Debian Jessie, and Debian Stretch. Since Jessie is very old, this PR will only pull the `stretch` tags. Come mid-2019, we'll also want to add `buster` as well which will be the Debian 10 release which the OpenJDK Docker Team is planning to use.