### PR TITLE
Fix buildpack-deps.

### DIFF
--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -11,7 +11,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # switch to Stretch.
 RUN if grep -q Debian /etc/os-release && grep -q jessie /etc/os-release; then \
 	rm /etc/apt/sources.list \
-    && echo "deb http://deb.debian.org/debian/ jessie main" >> /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian/ jessie main" >> /etc/apt/sources.list \
+    && echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list \
 	; fi
 
 # man directory is missing in some base images


### PR DESCRIPTION
This PR fixes the `buildpack-deps` image/job that's failing. It also adds a missing repository (that I removed in #368) that isn't needed in our other images but could be useful to have anyway since it was initially present.