### PR TITLE
[CIRCLE-17179] [WIP] Store current tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,6 +301,9 @@ jobs:
       - store_test_results:
           path: test-results
 
+      - store_artifacts:
+          path: CURRENT_TAGS.txt
+
   publish_android:
     <<: *publish_image
     parallelism: 6 # don't increase or decrease this, it correlates to the number of API versions we build in android/generate images

--- a/shared/images/build.sh
+++ b/shared/images/build.sh
@@ -41,7 +41,7 @@ function update_aliases() {
           docker tag ${IMAGE_NAME} ${ALIAS_NAME}
           docker push ${ALIAS_NAME}
 
-          echo "${ALIAS_NAME}" >> CURRENT_TAGS.txt
+          echo "${ALIAS_NAME}" >> ~/circleci-bundles/CURRENT_TAGS.txt
 
           docker image rm ${ALIAS_NAME}
         else
@@ -50,13 +50,13 @@ function update_aliases() {
             docker tag ${IMAGE_NAME} ${ALIAS_NAME}
             docker push ${ALIAS_NAME}
 
-            echo "${ALIAS_NAME}" >> CURRENT_TAGS.txt
+            echo "${ALIAS_NAME}" >> ~/circleci-bundles/CURRENT_TAGS.txt
 
             docker image rm ${ALIAS_NAME}
             docker tag ${IMAGE_NAME} ${ALIAS_NAME_BRANCH_COMMIT}
             docker push ${ALIAS_NAME_BRANCH_COMMIT}
 
-            echo "${ALIAS_NAME_BRANCH_COMMIT}" >> CURRENT_TAGS.txt
+            echo "${ALIAS_NAME_BRANCH_COMMIT}" >> ~/circleci-bundles/CURRENT_TAGS.txt
 
             docker image rm ${ALIAS_NAME_BRANCH_COMMIT}
           fi
@@ -131,7 +131,7 @@ function handle_ccitest_org_images() {
         IMAGE_NAME_BRANCH_COMMIT=${REPO_NAME}:$(cat TAG)-${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:12}
         docker tag ${IMAGE_NAME} ${IMAGE_NAME_BRANCH_COMMIT}
         docker push $IMAGE_NAME_BRANCH_COMMIT
-        echo "$IMAGE_NAME_BRANCH_COMMIT" >> CURRENT_TAGS.txt
+        echo "$IMAGE_NAME_BRANCH_COMMIT" >> ~/circleci-bundles/CURRENT_TAGS.txt
     fi
 }
 
@@ -152,7 +152,7 @@ then
     if [[ $PUSH_IMAGES == true ]]; then
         docker push $IMAGE_NAME
 
-        echo "$IMAGE_NAME" >> CURRENT_TAGS.txt
+        echo "$IMAGE_NAME" >> ~/circleci-bundles/CURRENT_TAGS.txt
 
         handle_ccitest_org_images
 

--- a/shared/images/build.sh
+++ b/shared/images/build.sh
@@ -40,15 +40,24 @@ function update_aliases() {
         if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "staging" ]]; then
           docker tag ${IMAGE_NAME} ${ALIAS_NAME}
           docker push ${ALIAS_NAME}
+
+          echo "${ALIAS_NAME}" >> CURRENT_TAGS.txt
+
           docker image rm ${ALIAS_NAME}
         else
           # because we're in a for loop, this var will be set from previous iterations, so grep for the current ALIAS_NAME (which gets reset on every iteration)
           if [[ $(echo $ALIAS_NAME_BRANCH_COMMIT | grep $ALIAS_NAME) ]]; then
             docker tag ${IMAGE_NAME} ${ALIAS_NAME}
             docker push ${ALIAS_NAME}
+
+            echo "${ALIAS_NAME}" >> CURRENT_TAGS.txt
+
             docker image rm ${ALIAS_NAME}
             docker tag ${IMAGE_NAME} ${ALIAS_NAME_BRANCH_COMMIT}
             docker push ${ALIAS_NAME_BRANCH_COMMIT}
+
+            echo "${ALIAS_NAME_BRANCH_COMMIT}" >> CURRENT_TAGS.txt
+
             docker image rm ${ALIAS_NAME_BRANCH_COMMIT}
           fi
         fi
@@ -122,6 +131,7 @@ function handle_ccitest_org_images() {
         IMAGE_NAME_BRANCH_COMMIT=${REPO_NAME}:$(cat TAG)-${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:12}
         docker tag ${IMAGE_NAME} ${IMAGE_NAME_BRANCH_COMMIT}
         docker push $IMAGE_NAME_BRANCH_COMMIT
+        echo "$IMAGE_NAME_BRANCH_COMMIT" >> CURRENT_TAGS.txt
     fi
 }
 
@@ -141,6 +151,8 @@ then
 
     if [[ $PUSH_IMAGES == true ]]; then
         docker push $IMAGE_NAME
+
+        echo "$IMAGE_NAME" >> CURRENT_TAGS.txt
 
         handle_ccitest_org_images
 


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

start working on a solution to better / more easily (for customers) display, not just every tag that exists, & not just the full dockerfiles for each commit, but the specific lists of tags pushed on each commit, so folks can figure out, at a glance, which tags have been recently built vs. which ones are likely older / may not include recent bugfixes / patches / etc.

### Description
currently, we are just storing each tag as a CircleCI artifact, AFTER it's been pushed to Docker Hub (to ensure that every tag we store, really has been published), but we should then aggregate them somehow & store them at some static endpoint
