### PR TITLE
Avoid installation caches in image layers

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -29,7 +29,7 @@ RUN sudo apt-get update -qqy && sudo apt-get install -qqy \
 RUN sudo apt-get install gcc-multilib && \
     sudo easy_install -U pip && \
     sudo pip uninstall crcmod && \
-    sudo pip install -U crcmod
+    sudo pip install --no-cache -U crcmod
 
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -27,7 +27,7 @@ RUN sudo apt-get update -qqy && sudo apt-get install -qqy \
         lsb-release && \
     sudo rm -rf /var/lib/apt/lists/*
 
-RUN sudo apt-get install gcc-multilib && \
+RUN sudo apt-get update && sudo apt-get install gcc-multilib && \
     sudo rm -rf /var/lib/apt/lists/* && \
     sudo easy_install -U pip && \
     sudo pip uninstall crcmod && \

--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -24,9 +24,11 @@ RUN sudo apt-get update -qqy && sudo apt-get install -qqy \
         python-dev \
         python-setuptools \
         apt-transport-https \
-        lsb-release
+        lsb-release && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 RUN sudo apt-get install gcc-multilib && \
+    sudo rm -rf /var/lib/apt/lists/* && \
     sudo easy_install -U pip && \
     sudo pip uninstall crcmod && \
     sudo pip install --no-cache -U crcmod
@@ -36,6 +38,7 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 RUN sudo apt-get update && sudo apt-get install -y google-cloud-sdk && \
+    sudo rm -rf /var/lib/apt/lists/* && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
 
@@ -48,7 +51,8 @@ RUN sudo apt-get update && \
     sudo apt-get install --yes \
         xvfb lib32z1 lib32stdc++6 build-essential \
         libcurl4-openssl-dev libglu1-mesa libxi-dev libxmu-dev \
-        libglu1-mesa-dev
+        libglu1-mesa-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # Install Ruby
 RUN cd /tmp && wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz && \

--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -55,12 +55,14 @@ RUN sudo apt-get update && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Install Ruby
-RUN cd /tmp && wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz && \
+RUN sudo apt-get update && \
+    cd /tmp && wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz && \
     tar -xzvf ruby-install-0.6.1.tar.gz && \
     cd ruby-install-0.6.1 && \
     sudo make install && \
     ruby-install --cleanup ruby 2.4.3 && \
-    rm -r /tmp/ruby-install-*
+    rm -r /tmp/ruby-install-* && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 ENV PATH ${HOME}/.rubies/ruby-2.4.3/bin:${PATH}
 RUN echo 'gem: --env-shebang --no-rdoc --no-ri' >> ~/.gemrc && gem install bundler

--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -59,12 +59,10 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz
   && rm /tmp/sbt.tgz \
   && /opt/sbt/bin/sbt sbtVersion
 
-# Install openjfx
-RUN apt-get install -y --no-install-recommends openjfx \
-    && rm -rf /var/lib/apt/lists/*
-
-# Add build-essential
-RUN apt-get install -y build-essential \
+# Install openjfx and build-essential
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjfx \
+    && apt-get install -y build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 EOF

--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -60,10 +60,12 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz
   && /opt/sbt/bin/sbt sbtVersion
 
 # Install openjfx
-RUN apt-get install -y --no-install-recommends openjfx
+RUN apt-get install -y --no-install-recommends openjfx \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add build-essential
-RUN apt-get install -y build-essential
+RUN apt-get install -y build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 EOF
 

--- a/php/generate-images
+++ b/php/generate-images
@@ -20,7 +20,8 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
 RUN (pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.7.0beta1) && docker-php-ext-enable xdebug
 
 # Install common extensions
-RUN apt install -y libicu-dev zlib1g-dev libzip-dev
+RUN apt install -y libicu-dev zlib1g-dev libzip-dev && \
+    rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure intl && docker-php-ext-install intl
 RUN docker-php-ext-install zip
 

--- a/python/generate-images
+++ b/python/generate-images
@@ -7,7 +7,7 @@ VARIANTS=(browsers node node-browsers)
 IMAGE_CUSTOMIZATIONS=$(cat <<'EOF'
 
 # Install pipenv and poetry
-RUN sudo pip install pipenv poetry
+RUN sudo pip install --no-cache pipenv poetry
 
 EOF
 )


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This avoids including the apt-get and pip installation cache files in the Docker image layers, which follows Dockerfile best practices.

This should reduce the size of the Python images for example by about 20 to 30 MB (estimated), which I imagine is significant when multiplied by all pulls.

Background for apt-get:

* https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get