### PR TITLE
all: Don't build Debian Buster and Sid.

### DIFF
--- a/shared/images/generate.sh
+++ b/shared/images/generate.sh
@@ -27,7 +27,7 @@ function find_tags_and_aliases() {
   curl --silent --location --fail --retry 3 "$MANIFEST_SOURCE" \
     | grep Tags \
     | sed  's/^.*Tags: //g' \
-    | grep -v $ALPINE_TAG -e 'slim' -e 'onbuild' -e windows -e wheezy -e nanoserver \
+    | grep -v $ALPINE_TAG -e 'slim' -e 'onbuild' -e windows -e wheezy -e nanoserver -e sid -e buster \
     | ${TAG_FILTER} \
     | ${TAG_INCLUDE_FILTER} \
     | sed 's/, /:/' \


### PR DESCRIPTION
This fixes the buildpack-deps job that is failing.

The `-browsers` and `--browsers-legacy` variants install OpenJDK 8. This is no longer available n Debian Sid nor Debian Buster (which is currently based on Sid).

We shouldn't be building Debian Sid (unstable) because by design, it's a moving, unstable target.

We shouldn't be building Debian Buster because it's not released yet. Once it's released later this year, we can start building it again.