### PR TITLE
mongo: Remove deprecated --noprealloc flag.

### DIFF
--- a/mongo/resources/Dockerfile-basic.template
+++ b/mongo/resources/Dockerfile-basic.template
@@ -1,3 +1,3 @@
 FROM {{BASE_IMAGE}}
 
-CMD ["mongod", "--nojournal", "--noprealloc", "--smallfiles"]
+CMD ["mongod", "--nojournal", "--smallfiles"]

--- a/mongo/resources/Dockerfile-ram.template
+++ b/mongo/resources/Dockerfile-ram.template
@@ -5,4 +5,4 @@ FROM {{BASE_IMAGE}}
 # entrypoint file. This comment can be removed once all pre-3.6 mongo images are gone.
 RUN sed -i '/exec "$@"/i mkdir \/dev\/shm\/mongo' /usr/local/bin/docker-entrypoint.sh
 
-CMD ["mongod", "--nojournal", "--noprealloc", "--smallfiles", "--dbpath=/dev/shm/mongo"]
+CMD ["mongod", "--nojournal", "--smallfiles", "--dbpath=/dev/shm/mongo"]


### PR DESCRIPTION
The `--noprealloc` flag has been deprecated in MongoDB for awhile now. Starting with the v4.1 release, it's now erroring out causing builds to fail for users. This PR removes this flag.

Fixes #371.

https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-noprealloc