### PR TITLE
Install Musl for Rust Images

### DIFF
--- a/rust/generate-images
+++ b/rust/generate-images
@@ -4,5 +4,13 @@ NAME=Rust
 BASE_REPO=rust
 VARIANTS=(browsers node node-browsers)
 
+IMAGE_CUSTOMIZATIONS=$(cat <<'EOF'
+
+# install musl libc for static binaries
+RUN apt-get install -y musl musl-dev musl-tools
+
+EOF
+)
+
 source ../shared/images/generate-node.sh
 source ../shared/images/generate.sh

--- a/rust/goss.yaml
+++ b/rust/goss.yaml
@@ -7,6 +7,14 @@ file:
   /home/circleci:
     exists: true
 
+package:
+  musl:
+    installed: true
+  musl-dev:
+    installed: true
+  musl-tools:
+    installed: true
+
 user:
   # ensure circleci user exists
   circleci:


### PR DESCRIPTION
musl is a tiny libc implementation and helps create cross-distro static binaries.

<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

A common use-case in Rust is to use [musl](https://www.musl-libc.org/) as a tiny `libc` implementation to build static binaries without any share library linkage, similar to the binaries that Golang produces by default. In order to compile these binaries, the following criteria should be met:

 1. `rustup target add x86_64-unknown-linux-musl`: add the toolchain
 2. install `musl` to add a `musl-gcc` binary for actually doing the compilation.

Since `circleci/rust` does not do any Rust-specific customizations to the base image, I have not added the toolchain but I have installed the musl packages to make static binary compilation possible.

### Description

This change simply installs the `musl`, `musl-dev`, and `musl-tools` into the image to make compilation to static `x86_64-unknown-linux-musl` binaries possible, provided that the Rust musl toolchain is installed for the given architecture.
