### PR TITLE
mongo: Fix MongoDB v4.1.x startup.

### DIFF
--- a/mongo/resources/Dockerfile-basic.template
+++ b/mongo/resources/Dockerfile-basic.template
@@ -1,3 +1,3 @@
 FROM {{BASE_IMAGE}}
 
-CMD ["mongod", "--nojournal", "--smallfiles"]
+CMD ["mongod", "--nojournal"]

--- a/mongo/resources/Dockerfile-ram.template
+++ b/mongo/resources/Dockerfile-ram.template
@@ -1,8 +1,5 @@
 FROM {{BASE_IMAGE}}
 
-# The ENTRYPOINT for mongo is at /usr/local/bin/docker-entrypoint.sh, but pre-3.6 images also
-# include a symlink from /entrypoint.sh to that script. So, it's only necessary to update the real
-# entrypoint file. This comment can be removed once all pre-3.6 mongo images are gone.
-RUN sed -i '/exec "$@"/i mkdir \/dev\/shm\/mongo' /usr/local/bin/docker-entrypoint.sh
+RUN mkdir /dev/shm/mongo
 
-CMD ["mongod", "--nojournal", "--smallfiles", "--dbpath=/dev/shm/mongo"]
+CMD ["mongod", "--nojournal", "--dbpath=/dev/shm/mongo"]


### PR DESCRIPTION
This is a continuation of #383. MongoDB v4.1.x still isn't starting.