### PR TITLE
Create mongo-ram shared memory dbpath on container start.

### DIFF
--- a/mongo/resources/Dockerfile-ram.template
+++ b/mongo/resources/Dockerfile-ram.template
@@ -1,5 +1,8 @@
 FROM {{BASE_IMAGE}}
 
-RUN mkdir /dev/shm/mongo
+# The ENTRYPOINT for mongo is at /usr/local/bin/docker-entrypoint.sh, but pre-3.6 images also	RUN mkdir /dev/shm/mongo
+# include a symlink from /entrypoint.sh to that script. So, it's only necessary to update the real
+# entrypoint file. This comment can be removed once all pre-3.6 mongo images are gone.
+RUN sed -i '/exec "$@"/i mkdir \/dev\/shm\/mongo' /usr/local/bin/docker-entrypoint.sh
 
 CMD ["mongod", "--nojournal", "--dbpath=/dev/shm/mongo"]


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to #387.

Currently `mongo:*-ram` images aren't able to start because the dbpath directory (in shared memory) doesn't exist. 

### Description

Alter the `mongo:*-ram` template to create the (shared memory) dbpath at container run-time instead of trying to create it at build time (reverting part of 93920c60a11c41a074957904d9e0b69badcd9dba). 

I was not able to get the tests to run on my system (I am not sure how to construct the `circleci-bundles` folder structure), but I manually started each generated `mongo:*-ram` image to confirm that it started correctly.
