### PR TITLE
Move away from the beta version of xdebug in PHP 7.3

### DIFF
--- a/php/generate-images
+++ b/php/generate-images
@@ -17,7 +17,7 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
     mv composer.phar /usr/local/bin/composer
 
 # Install XDebug
-RUN (pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.7.0beta1) && docker-php-ext-enable xdebug
+RUN (pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.7.1) && docker-php-ext-enable xdebug
 
 # Install common extensions
 RUN apt install -y libicu-dev zlib1g-dev libzip-dev


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to moving away from a beta version of xdebug.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

Moving to the latest version of xdebug available for PHP 7.3.