### PR TITLE
Build Android Q Beta API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
 
   publish_android:
     <<: *publish_image
-    parallelism: 6 # don't increase or decrease this, it correlates to the number of API versions we build in android/generate images
+    parallelism: 7 # don't increase or decrease this, it correlates to the number of API versions we build in android/generate images
     environment:
       - PLATFORM: android
 

--- a/android/generate-images
+++ b/android/generate-images
@@ -21,6 +21,11 @@ function generate_dockerfile {
 # if we want to add another API version, bump paralellism by 1
 if [[ "$CIRCLE_NODE_TOTAL" -gt 1 ]]; then
   let API=${CIRCLE_NODE_INDEX}+23
+  
+  if [[ $API == 29 ]]; then
+	  API=Q
+  fi
+
   echo Generating Android ${API} Dockerfiles
 
   tag=api-${API}
@@ -40,7 +45,7 @@ if [[ "$CIRCLE_NODE_TOTAL" -gt 1 ]]; then
   # create specific NDK dockerfiles (call m4 here when we want multiple NDK versions)
   cat Dockerfile-ndk.template >> "${ndk_variant_dockerfile}"
 else
-  for API in 23 24 25 26 27 28; do
+  for API in 23 24 25 26 27 28 Q; do
     echo Generating Android ${API} Dockerfiles
 
     tag=api-${API}


### PR DESCRIPTION
Adds support for the Android Q beta. The images generated from this PR are experimental. They are to help developers prepare for the upcoming Android 10/Q/API 29 release.

If this gets merged, the changes in lines 25-28 in the `generate-images` file should be reverted once the level Q API officially becomes the level 29 API.