### PR TITLE
rust: install rustfmt

### DIFF
--- a/rust/generate-images
+++ b/rust/generate-images
@@ -6,6 +6,8 @@ VARIANTS=(browsers node node-browsers)
 
 IMAGE_CUSTOMIZATIONS=$(cat <<'EOF'
 
+RUN rustup component add rustfmt
+
 # install musl libc for static binaries
 RUN apt-get install -y musl musl-dev musl-tools
 


### PR DESCRIPTION
### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

The official Rust Docker image does not install `rustfmt`. The tool is, however, often used in CI workflows
to check formatting of submitted changes.

Tested by building the image and verifying that `rustfmt` and `cargo fmt` commands are usable.

### Description

Added `RUN rustup component add rustfmt` as an image customization step. 
