### PR TITLE
Set local/bin for circleci user.

### DIFF
--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -17,6 +17,7 @@ RUN if grep -q Debian /etc/os-release && grep -q jessie /etc/os-release; then \
 
 # Make sure PATH includes ~/.local/bin
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839155
+# This only works for root. The circleci user is done near the end of this Dockerfile
 RUN echo 'PATH="$HOME/.local/bin:$PATH"' >> /etc/profile.d/user-local-path.sh
 
 # man directory is missing in some base images
@@ -88,5 +89,8 @@ RUN groupadd --gid 3434 circleci \
 # END IMAGE CUSTOMIZATIONS
 
 USER circleci
+
+# Physically create these directories so that ~/.profile will add them to PATH
+RUN mkdir -p $HOME/{,.local/}bin
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Fixes #420 

After the `circleci` user is created, this PR manually creates the `$HOME/bin` and `$HOME/.local/bin` directories. This allows the `$HOME/.profile` script to automatically add those directories to the `PATH`.