### PR TITLE
OpenJDK: Reenable v8 build for old image.

### DIFF
--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -5,7 +5,9 @@ BASE_REPO=openjdk
 VARIANTS=(browsers node node-browsers)
 
 TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
-TAG_INCLUDE_FILTER="grep stretch"
+# 8-jdk is explicitly added due to it being an old, Debian-based image, it 
+# doesn't need a -stretch or -buster tag but is stretch
+TAG_INCLUDE_FILTER="grep -e 8-jdk -e stretch -e buster"
 
 function generate_customizations() {
 


### PR DESCRIPTION
OpenJDK v8 images (`8-jdk-`) weren't building. This was because of upstream changing their base from Debian to Oracle and our reaction to it. This image was dropped in the switch. Restoring these builds.