### PR TITLE
Fix git user setting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,15 @@ jobs:
       - run:
           name: git config, git clone
           command: |
-            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-            git config --global user.name "$CIRCLE_USERNAME"
+            if [ ! -z "$CIRCLE_USERNAME" ]; then
+
+              git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+              git config --global user.name "$CIRCLE_USERNAME"
+            else
+
+              git config --global user.email "community-partner@circleci.com"
+              git config --global user.name "cpe-team"
+            fi
 
             git clone git@github.com:CircleCI-Public/circleci-dockerfiles.git
 


### PR DESCRIPTION
The CircleCI envar `CIRCLE_USERNAME` now doesn't populate on scheduled workflows. When this happens, our job to generate Dockerfiles and push to GitHub is failing.

This PR fixes this by manually setting an email and username when the variable is empty.