### PR TITLE
Fix node lts 12

### DIFF
--- a/android/generate-images
+++ b/android/generate-images
@@ -17,7 +17,7 @@ function generate_dockerfile {
   echo "${dockerfile_path}"
 }
 
-# we can set parallelism to 6 to cover all API versions (23 through 29)
+# we can set parallelism to 7 to cover all API versions (23 through 29)
 # if we want to add another API version, bump paralellism by 1
 if [[ "$CIRCLE_NODE_TOTAL" -gt 1 ]]; then
   let API=${CIRCLE_NODE_INDEX}+23

--- a/shared/images/generate-node.sh
+++ b/shared/images/generate-node.sh
@@ -17,7 +17,7 @@ RUN whoami
 USER root
 EOF
 
-  NODE_MANIFEST_INFO=$(curl --silent --location --fail --retry 3 https://raw.githubusercontent.com/docker-library/official-images/master/library/node | grep -A3 "$DESIRED_NODE_TAG")
+  NODE_MANIFEST_INFO=$(curl --silent --location --fail --retry 3 https://raw.githubusercontent.com/docker-library/official-images/master/library/node | grep -A 3 "$DESIRED_NODE_TAG")
   NODE_GIT_COMMIT=$(printf "%s\n" "${NODE_MANIFEST_INFO}" | grep GitCommit | awk '{print $2;}')
   NODE_DIRECTORY=$(printf "%s\n" "${NODE_MANIFEST_INFO}" | grep Directory | awk '{print $2;}')
 
@@ -46,7 +46,7 @@ function generate_node_browser_legacy_variant() {
 }
 
 mkdir -p resources
-generate_node_variant "lts$" > resources/Dockerfile-node.template
+generate_node_variant "lts[$,]" > resources/Dockerfile-node.template
 generate_node_browser_variant > resources/Dockerfile-node-browsers.template
 generate_node_browser_legacy_variant > resources/Dockerfile-node-browsers-legacy.template
 


### PR DESCRIPTION
With Node.js v12 becoming the new LTS, the build system for our `-node` variants failed.

This was due to a simple regex problem. The tag `lts` is no longer last in the list of tags. This fix allows the tag to be somewhere in the list that's not last.