### PR TITLE
Disable PostgreSQL Alpine builds.

### DIFF
--- a/postgres/generate-images
+++ b/postgres/generate-images
@@ -4,7 +4,7 @@ NAME=PostgreSQL
 BASE_REPO=postgres
 VARIANTS=(ram postgis postgis-ram)
 
-INCLUDE_ALPINE=true
+INCLUDE_ALPINE=false
 
 TAG_FILTER="grep -v -e ^13"
 


### PR DESCRIPTION
Disables the building of Alpine-based PostgreSQL images. They're too unstable for us. The second largest reason for build failures is Alpine.