### PR TITLE
Adds support for Postgres 13

### DIFF
--- a/postgres/generate-images
+++ b/postgres/generate-images
@@ -6,7 +6,7 @@ VARIANTS=(ram postgis postgis-ram)
 
 INCLUDE_ALPINE=false
 
-TAG_FILTER="grep -v -e ^13"
+TAG_FILTER="grep -v -e ^14"
 
 source ../shared/images/generate.sh
 

--- a/postgres/resources/Dockerfile-postgis.template
+++ b/postgres/resources/Dockerfile-postgis.template
@@ -1,13 +1,13 @@
 FROM {{BASE_IMAGE}}
 
 ENV PGUSER $POSTGRES_USER
-# PostGIS version for non-v12 PostgreSQL
-# v12 defaults to PostGIS v3
+# PostGIS version for versions prior to v12 PostgreSQL
+# v12 and above defaults to PostGIS v3
 ENV POSTGIS_PKG_VER 2.5
 ENV POSTGIS_VERSION 2.5.3
 
 RUN if which apt-get > /dev/null ; then \
-      if [ $PG_MAJOR = 12 ]; then \
+      if [ $PG_MAJOR -ge 12 ]; then \
 	    echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg-testing main" >> /etc/apt/sources.list.d/pgdg.list && \
         apt-get update && \
         apt-get install -y --no-install-recommends \


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

Postgres 13 is GA as of September 24th, 2020 - https://www.postgresql.org/about/news/postgresql-13-released-2077/


### Description

This PR follows the pattern of https://github.com/circleci/circleci-images/pull/442 when Postgres 12 was officially added. The logic for determining which PostGIS version to use now checks for versions greater than or equal to 12 for forward compatibility. (PostGIS 2.x is not supported on PG 13 at all)