### PR TITLE
Remove MYSQL_USER ENV (#540)

### DIFF
--- a/mysql/resources/Dockerfile-basic.template
+++ b/mysql/resources/Dockerfile-basic.template
@@ -3,8 +3,7 @@ FROM {{BASE_IMAGE}}
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_DATABASE=circle_test \
     MYSQL_HOST=127.0.0.1 \
-    MYSQL_ROOT_HOST=% \
-    MYSQL_USER=root
+    MYSQL_ROOT_HOST=%
 
 # This is the performance optimization tweak to make DB faster
 RUN echo '\n\


### PR DESCRIPTION
Bring the changes from https://github.com/circleci/circleci-images/pull/540 into the main branch.

As described in https://github.com/docker-library/mysql/issues/750#issuecomment-801792228, `MYSQL_USER=root` is redundant and now causes an error, so we should remove it.
