### PR TITLE
Update Android NDK to r21e

### DIFF
--- a/android/Dockerfile-ndk.template
+++ b/android/Dockerfile-ndk.template
@@ -1,5 +1,5 @@
 
-ARG ndk_version=android-ndk-r20
+ARG ndk_version=android-ndk-r21e
 ARG android_ndk_home=/opt/android/${ndk_version}
 
 # install NDK


### PR DESCRIPTION
### Checklist
- [ ] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR relates to <issue>.

The Android NDK image for API version 30 does not support NDK API version 30.

### Description
Bump NDK version to support NDK 30 APIs.
