### PR TITLE
Add Support for AdoptOpenJDK and other Small Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ php/resources/
 python/resources/
 ruby/resources/
 rust/resources/
+adoptopenjdk/resources/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUNDLES = \
   android node python ruby golang php \
   postgres mariadb mysql mongo dynamodb elixir erlang \
-  jruby clojure openjdk buildpack-deps redis rust
+  jruby clojure openjdk buildpack-deps redis rust adoptopenjdk
 
 images: $(foreach b, $(BUNDLES), $(b)/generate_images)
 

--- a/adoptopenjdk/generate-images
+++ b/adoptopenjdk/generate-images
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-NAME=Java
-BASE_REPO=openjdk
+NAME=AdoptOpenJDK
+BASE_REPO=adoptopenjdk
 VARIANTS=(browsers node node-browsers)
 
-TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
-# 8-jdk is explicitly added due to it being an old, Debian-based image, it 
-# doesn't need a -stretch or -buster tag but is stretch
-TAG_INCLUDE_FILTER="grep -e 8-jdk -e stretch -e buster"
+TAG_FILTER="grep -v -e jre"
+#TAG_INCLUDE_FILTER="grep -e 8-jdk- -e 11-jdk- -e 15-jdk- -e 16-jdk-"
 
 function generate_customizations() {
 
@@ -26,23 +24,29 @@ function generate_customizations() {
 #   aws s3 cp - s3://circle-downloads/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts --acl public-read
 RUN if java -fullversion 2>&1 | grep -q '"9.'; then \
   curl --silent --show-error --location --fail --retry 3 --output /etc/ssl/certs/java/cacerts \
-       https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts; \
+       https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-\$(dpkg --print-architecture)/openjdk-9-slim-cacerts; \
  fi
 
 # Install Maven Version: $MAVEN_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz \
     https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz.sha512 \
+    https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 \
+  && echo "\$(cat /tmp/apache-maven.tar.gz.sha512) /tmp/apache-maven.tar.gz" | sha512sum -c \
   && tar xf /tmp/apache-maven.tar.gz -C /opt/ \
-  && rm /tmp/apache-maven.tar.gz \
+  && rm /tmp/apache-maven.tar.gz /tmp/apache-maven.tar.gz.sha512 \
   && ln -s /opt/apache-maven-* /opt/apache-maven \
   && /opt/apache-maven/bin/mvn -version
 
 # Install Ant Version: $ANT_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz \
     https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz.sha512 \
+    https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz.sha512 \
+  && echo "\$(cat /tmp/apache-ant.tar.gz.sha512) /tmp/apache-ant.tar.gz" | sha512sum -c \
   && tar xf /tmp/apache-ant.tar.gz -C /opt/ \
   && ln -s /opt/apache-ant-* /opt/apache-ant \
-  && rm -rf /tmp/apache-ant.tar.gz \
+  && rm -rf /tmp/apache-ant.tar.gz /tmp/apache-ant.tar.gz.sha512 \
   && /opt/apache-ant/bin/ant -version
 
 ENV ANT_HOME=/opt/apache-ant
@@ -50,8 +54,11 @@ ENV ANT_HOME=/opt/apache-ant
 # Install Gradle Version: $GRADLE_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip \
     https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip.sha256 \
+    https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip.sha256 \
+  && echo "\$(cat /tmp/gradle.zip.sha256) /tmp/gradle.zip" | sha256sum -c \
   && unzip -d /opt /tmp/gradle.zip \
-  && rm /tmp/gradle.zip \
+  && rm /tmp/gradle.zip /tmp/gradle.zip.sha256 \
   && ln -s /opt/gradle-* /opt/gradle \
   && /opt/gradle/bin/gradle -version
 
@@ -59,7 +66,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz ${SBT_URL} \
   && tar -xzf /tmp/sbt.tgz -C /opt/ \
   && rm /tmp/sbt.tgz \
-  && /opt/sbt/bin/sbt sbtVersion
+  && /opt/sbt/bin/sbt -Dsbt.rootdir=true sbtVersion
 
 # Install openjfx and build-essential
 RUN apt-get update \
@@ -78,7 +85,7 @@ ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin
 RUN mvn -version \
   && ant -version \
   && gradle -version \
-  && sbt sbtVersion
+  && sbt -Dsbt.rootdir=true sbtVersion
 
 EOF
 }

--- a/adoptopenjdk/generate-images
+++ b/adoptopenjdk/generate-images
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+NAME=Java
+BASE_REPO=openjdk
+VARIANTS=(browsers node node-browsers)
+
+TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
+# 8-jdk is explicitly added due to it being an old, Debian-based image, it 
+# doesn't need a -stretch or -buster tag but is stretch
+TAG_INCLUDE_FILTER="grep -e 8-jdk -e stretch -e buster"
+
+function generate_customizations() {
+
+  MAVEN_VERSION=$(./java_helper maven)
+  ANT_VERSION=$(./java_helper ant)
+  GRADLE_VERSION=$(./java_helper gradle)
+  SBT_URL=$(./java_helper sbt)
+
+  cat <<EOF
+
+# cacerts from OpenJDK 9-slim to workaround http://bugs.java.com/view_bug.do?bug_id=8189357
+# AND https://github.com/docker-library/openjdk/issues/145
+#
+# Created by running:
+# docker run --rm openjdk:9-slim cat /etc/ssl/certs/java/cacerts | \
+#   aws s3 cp - s3://circle-downloads/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts --acl public-read
+RUN if java -fullversion 2>&1 | grep -q '"9.'; then \
+  curl --silent --show-error --location --fail --retry 3 --output /etc/ssl/certs/java/cacerts \
+       https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts; \
+ fi
+
+# Install Maven Version: $MAVEN_VERSION
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz \
+    https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && tar xf /tmp/apache-maven.tar.gz -C /opt/ \
+  && rm /tmp/apache-maven.tar.gz \
+  && ln -s /opt/apache-maven-* /opt/apache-maven \
+  && /opt/apache-maven/bin/mvn -version
+
+# Install Ant Version: $ANT_VERSION
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz \
+    https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+  && tar xf /tmp/apache-ant.tar.gz -C /opt/ \
+  && ln -s /opt/apache-ant-* /opt/apache-ant \
+  && rm -rf /tmp/apache-ant.tar.gz \
+  && /opt/apache-ant/bin/ant -version
+
+ENV ANT_HOME=/opt/apache-ant
+
+# Install Gradle Version: $GRADLE_VERSION
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip \
+    https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  && unzip -d /opt /tmp/gradle.zip \
+  && rm /tmp/gradle.zip \
+  && ln -s /opt/gradle-* /opt/gradle \
+  && /opt/gradle/bin/gradle -version
+
+# Install sbt from $SBT_URL
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz ${SBT_URL} \
+  && tar -xzf /tmp/sbt.tgz -C /opt/ \
+  && rm /tmp/sbt.tgz \
+  && /opt/sbt/bin/sbt sbtVersion
+
+# Install openjfx and build-essential
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjfx \
+    && apt-get install -y build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+EOF
+
+  # Modify path but don't inject builder path in there!
+  cat <<'EOF'
+# Update PATH for Java tools
+ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin:$PATH"
+
+# smoke test with path
+RUN mvn -version \
+  && ant -version \
+  && gradle -version \
+  && sbt sbtVersion
+
+EOF
+}
+
+IMAGE_CUSTOMIZATIONS=$(generate_customizations)
+
+source ../shared/images/generate-node.sh
+source ../shared/images/generate.sh

--- a/adoptopenjdk/generate-images
+++ b/adoptopenjdk/generate-images
@@ -5,7 +5,6 @@ BASE_REPO=adoptopenjdk
 VARIANTS=(browsers node node-browsers)
 
 TAG_FILTER="grep -v -e jre"
-#TAG_INCLUDE_FILTER="grep -e 8-jdk- -e 11-jdk- -e 15-jdk- -e 16-jdk-"
 
 function generate_customizations() {
 

--- a/adoptopenjdk/goss.yaml
+++ b/adoptopenjdk/goss.yaml
@@ -1,0 +1,13 @@
+file:
+  # ensure a basic shell exists
+  /bin/sh:
+    exists: true
+
+  # ensure basic directory structure created
+  /home/circleci:
+    exists: true
+
+user:
+  # ensure circleci user exists
+  circleci:
+    exists: true

--- a/adoptopenjdk/java_helper
+++ b/adoptopenjdk/java_helper
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Java Helpers 
+# Provide functions to help with working with various java tools
+
+from distutils.version import LooseVersion
+import urllib2
+import re
+import argparse
+
+# Define some constants
+MAVEN_URL = 'https://www.apache.org/dist/maven/maven-3/'
+MAVEN_VERSION_PATTERN = r'\d+\.\d+\.\d+'
+GRADLE_URL = 'https://gradle.org/releases'
+GRADLE_VERSION_PATTERN = r'(<span>v\d+\.\d+(\.\d+)?)'
+ANT_URL = 'http://archive.apache.org/dist/ant/binaries/'
+ANT_VERSION_PATTERN = r'\d+\.\d+\.\d+'
+SBT_URL = 'https://www.scala-sbt.org/download.html'
+SBT_URL_PATTERN = r'https://[^"]*tgz'
+
+def get_latest_version(url, pattern):
+    """Return latest version of given tool 
+
+    Args:
+        url: url to search 
+        pattern: regex pattern to get version
+
+    Returns:
+        A string representing the latest version of a given tool 
+    """
+    raw_html = urllib2.urlopen(url).read()
+    raw_versions = re.finditer(pattern, raw_html)
+    # strip out any leading text 
+    clean_versions = map(lambda x: re.sub(r'^\D+', '', x.group()), raw_versions)
+    # use LooseVersion to account for (1.10 < 1.9 = True)
+    versions = sorted(clean_versions, key=LooseVersion)
+    if (len(versions) < 1):
+        raise Exception(
+            'Unable to find any versions from {0}, this is not expected'.format(url))
+    return versions[((len(versions) - 1))]
+
+def get_sbt_url(url, pattern):
+    """Returns cached SBT from GitHub download to avoid GitHub rate limiting and the like"""
+    return "https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/sbt-latest.tgz"
+    #raw_html = urllib2.urlopen(url).read()
+    #raw_urls = re.findall(pattern, raw_html)
+    #if (len(raw_urls) < 1):
+    #    raise Exception(
+    #        'Unable to find any urls from {0}, this is not expected'.format(url))
+    #return raw_urls[((len(raw_urls) - 1))]
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Get Latest Version of Java Tools.')
+    parser.add_argument('get', type=str, choices=['ant', 'gradle', 'maven', 'sbt'], 
+            help='get latest version of desired tool')
+    args = parser.parse_args()
+    if args.get == 'ant':
+        print(get_latest_version(ANT_URL, ANT_VERSION_PATTERN))
+    if args.get == 'gradle':
+        print(get_latest_version(GRADLE_URL, GRADLE_VERSION_PATTERN))
+    if args.get == 'maven':
+        print(get_latest_version(MAVEN_URL, MAVEN_VERSION_PATTERN))
+    if args.get == 'sbt':
+        print(get_sbt_url(SBT_URL, SBT_URL_PATTERN))

--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -26,23 +26,29 @@ function generate_customizations() {
 #   aws s3 cp - s3://circle-downloads/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts --acl public-read
 RUN if java -fullversion 2>&1 | grep -q '"9.'; then \
   curl --silent --show-error --location --fail --retry 3 --output /etc/ssl/certs/java/cacerts \
-       https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts; \
+       https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-\$(dpkg --print-architecture)/openjdk-9-slim-cacerts; \
  fi
 
 # Install Maven Version: $MAVEN_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz \
     https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz.sha512 \
+    https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 \
+  && echo "\$(cat /tmp/apache-maven.tar.gz.sha512) /tmp/apache-maven.tar.gz" | sha512sum -c \
   && tar xf /tmp/apache-maven.tar.gz -C /opt/ \
-  && rm /tmp/apache-maven.tar.gz \
+  && rm /tmp/apache-maven.tar.gz /tmp/apache-maven.tar.gz.sha512 \
   && ln -s /opt/apache-maven-* /opt/apache-maven \
   && /opt/apache-maven/bin/mvn -version
 
 # Install Ant Version: $ANT_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz \
     https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz.sha512 \
+    https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz.sha512 \
+  && echo "\$(cat /tmp/apache-ant.tar.gz.sha512) /tmp/apache-ant.tar.gz" | sha512sum -c \
   && tar xf /tmp/apache-ant.tar.gz -C /opt/ \
   && ln -s /opt/apache-ant-* /opt/apache-ant \
-  && rm -rf /tmp/apache-ant.tar.gz \
+  && rm -rf /tmp/apache-ant.tar.gz /tmp/apache-ant.tar.gz.sha512 \
   && /opt/apache-ant/bin/ant -version
 
 ENV ANT_HOME=/opt/apache-ant
@@ -50,8 +56,11 @@ ENV ANT_HOME=/opt/apache-ant
 # Install Gradle Version: $GRADLE_VERSION
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip \
     https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip.sha256 \
+    https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip.sha256 \
+  && echo "\$(cat /tmp/gradle.zip.sha256) /tmp/gradle.zip" | sha256sum -c \
   && unzip -d /opt /tmp/gradle.zip \
-  && rm /tmp/gradle.zip \
+  && rm /tmp/gradle.zip /tmp/gradle.zip.sha256 \
   && ln -s /opt/gradle-* /opt/gradle \
   && /opt/gradle/bin/gradle -version
 
@@ -59,7 +68,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz ${SBT_URL} \
   && tar -xzf /tmp/sbt.tgz -C /opt/ \
   && rm /tmp/sbt.tgz \
-  && /opt/sbt/bin/sbt sbtVersion
+  && /opt/sbt/bin/sbt -Dsbt.rootdir=true sbtVersion
 
 # Install openjfx and build-essential
 RUN apt-get update \
@@ -78,7 +87,7 @@ ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin
 RUN mvn -version \
   && ant -version \
   && gradle -version \
-  && sbt sbtVersion
+  && sbt -Dsbt.rootdir=true sbtVersion
 
 EOF
 }

--- a/shared/images/Dockerfile-basic.template
+++ b/shared/images/Dockerfile-basic.template
@@ -27,7 +27,7 @@ RUN apt-get update \
   && apt-get install -y \
     git mercurial xvfb apt \
     locales sudo openssh-client ca-certificates tar gzip parallel \
-    net-tools netcat unzip zip bzip2 gnupg curl wget make
+    net-tools netcat unzip zip bzip2 gnupg curl wget make dpkg
 
 
 # Set timezone to UTC by default
@@ -38,7 +38,7 @@ RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
 # install jq
-RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-$(dpkg --print-architecture)/jq-latest" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
   && chmod +x /usr/bin/jq \
   && jq --version
@@ -64,16 +64,16 @@ RUN set -ex \
   && (docker version || true)
 
 # docker compose
-RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-$(dpkg --print-architecture)/docker-compose-latest" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # install dockerize
-RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
-  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
-  && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-$(dpkg --print-architecture)/dockerize-latest.tar.gz" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-$(dpkg --print-architecture).tar.gz $DOCKERIZE_URL \
+  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-$(dpkg --print-architecture).tar.gz \
+  && rm -rf /tmp/dockerize-linux-$(dpkg --print-architecture).tar.gz \
   && dockerize --version
 
 RUN groupadd --gid 3434 circleci \

--- a/shared/images/manifest
+++ b/shared/images/manifest
@@ -107,7 +107,7 @@ def image_manifest(bundle):
     return info
 
 def manifest():
-    bundles = ['node', 'python', 'ruby', 'elixir', 'golang', 'clojure', 'php', 'openjdk', 'postgres', 'mariadb', 'mysql', 'mongo']
+    bundles = ['node', 'python', 'ruby', 'elixir', 'golang', 'clojure', 'php', 'openjdk', 'postgres', 'mariadb', 'mysql', 'mongo', 'adoptopenjdk']
     images = {}
     for b in bundles:
         images[b] = image_manifest(b)


### PR DESCRIPTION
### Checklist
- [X] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [X] I've updated the documentation if necessary.

### Motivation and Context

This PR adds support AdoptOpenJDK based images for users to build/test against. AdoptOpenJDK offers different JVM options compared to OpenJDK(like OpenJ9) plus other features lacking in OpenJDK.

Additionally, this PR adds some validation of Java tools downloaded for both OpenJDK and AdoptOpenJDK images.

Lastly, some modifications were made to the `Dockerfile-basic.template` to allow for architecture aware downloads/code.  

### Description
I used the OpenJDK directory as a starting point to add support for AdoptOpenJDK. Most of the code is similar as they both use debian/Ubuntu based containers.

I added checksum verification for all java tools downloaded, except `sbt` as it is downloaded via CircleCI's cache. Modifying `refresh-tools-cache` to also cache the checksums for the downloads would be a nice step going forward. This would allow for checksum verification for all downloads CircleCI uses for their Docker images.

I also fixed an error with `sbt` in the OpenJDK and AdoptOpenJDK images. Running the `sbt` command from the root directory leads to this error documented here: https://github.com/sbt/sbt/issues/1458

Adding the flag, `-Dsbt.rootdir=true`, allows you to build the Dockerfile with out error.

In `Dockerfile-basic.template`, I made sure the package `dpkg` was installed(it is usually installed on most debian based containers). This package will allow us to issue the command `dpkg --print-architecture` which should output the correct architecture you are running on. This is helpful to make your Docker containers multi-arch aware. Down the line if CircleCI does support an `arm64` Docker executor, this should allow your Dockerfiles to be compiled for multiple architectures without having separate Dockerfiles for each architecture. 
