### PR TITLE
Android: add support for build tools 30.0.3

### DIFF
--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -107,7 +107,8 @@ RUN sdkmanager \
   "build-tools;29.0.3" \
   "build-tools;30.0.0" \
   "build-tools;30.0.1" \
-  "build-tools;30.0.2"
+  "build-tools;30.0.2" \
+  "build-tools;30.0.3"
 
 # API_LEVEL string gets replaced by m4
 RUN sdkmanager "platforms;android-API_LEVEL"


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Build tools 30.0.3 are not available when fetching the android image

### Description
- Add support for Android build tools 30.0.3
