### PR TITLE
Fix OpenJDK issue with sbt

### DIFF
--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -4,7 +4,7 @@ NAME=Java
 BASE_REPO=openjdk
 VARIANTS=(browsers node node-browsers)
 
-TAG_FILTER="grep -v -e ^7 -e ^6 -e jre"
+TAG_FILTER="grep -v -e ^7 -e ^6 -e jre -e oraclelinux"
 # 8-jdk is explicitly added due to it being an old, Debian-based image, it 
 # doesn't need a -stretch or -buster tag but is stretch
 TAG_INCLUDE_FILTER="grep -e 8-jdk -e stretch -e buster"

--- a/openjdk/generate-images
+++ b/openjdk/generate-images
@@ -59,7 +59,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz ${SBT_URL} \
   && tar -xzf /tmp/sbt.tgz -C /opt/ \
   && rm /tmp/sbt.tgz \
-  && /opt/sbt/bin/sbt sbtVersion
+  && /opt/sbt/bin/sbt -Dsbt.rootdir=true sbtVersion
 
 # Install openjfx and build-essential
 RUN apt-get update \
@@ -78,7 +78,7 @@ ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin
 RUN mvn -version \
   && ant -version \
   && gradle -version \
-  && sbt sbtVersion
+  && sbt -Dsbt.rootdir=true sbtVersion
 
 EOF
 }


### PR DESCRIPTION
sbt can't be run from the root dir as-is. This adds a flag so that it doesn't fail.

This fix was borrowed from this PR: https://github.com/circleci/circleci-images/pull/549/files

Upstream change: https://github.com/sbt/sbt/pull/5112

There was also a second issue with the newly added Oracle Linux upstream base images. This was fixed as well.