### PR TITLE
Add Android API 31 and build tools 31.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
 
   publish_android:
     <<: *publish_image
-    parallelism: 8 # don't increase or decrease this, it correlates to the number of API versions we build in android/generate images
+    parallelism: 9 # don't increase or decrease this, it correlates to the number of API versions we build in android/generate images
     environment:
       - PLATFORM: android
 

--- a/android/Dockerfile.m4
+++ b/android/Dockerfile.m4
@@ -114,7 +114,8 @@ RUN sdkmanager \
   "build-tools;30.0.0" \
   "build-tools;30.0.1" \
   "build-tools;30.0.2" \
-  "build-tools;30.0.3"
+  "build-tools;30.0.3" \
+  "build-tools;31.0.0"
 
 # API_LEVEL string gets replaced by m4
 RUN sdkmanager "platforms;android-API_LEVEL"

--- a/android/generate-images
+++ b/android/generate-images
@@ -17,7 +17,7 @@ function generate_dockerfile {
   echo "${dockerfile_path}"
 }
 
-# we can set parallelism to 8 to cover all API versions (23 through 30)
+# we can set parallelism to 9 to cover all API versions (23 through 31)
 # if we want to add another API version, bump parallelism by 1
 if [[ "$CIRCLE_NODE_TOTAL" -gt 1 ]]; then
   let API=${CIRCLE_NODE_INDEX}+23
@@ -40,7 +40,7 @@ if [[ "$CIRCLE_NODE_TOTAL" -gt 1 ]]; then
   # create specific NDK dockerfiles (call m4 here when we want multiple NDK versions)
   cat Dockerfile-ndk.template >> "${ndk_variant_dockerfile}"
 else
-  for API in 23 24 25 26 27 28 29 30; do
+  for API in 23 24 25 26 27 28 29 30 31; do
     echo Generating Android ${API} Dockerfiles
 
     tag=api-${API}


### PR DESCRIPTION
<!-- Thanks for contributing to _circleci-images_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `make` from the root directory to see all Dockerfiles are created successfully.
- [x] I've updated the documentation if necessary.

### Motivation and Context
Android 12 (API 31) has now reached a platform stability milestone and is available for publishing through Google Play.

### Description
Add support for API 31 and build tools 31.0.0